### PR TITLE
Fix for Issue 214

### DIFF
--- a/src/com/eleybourn/bookcatalogue/BookEditFields.java
+++ b/src/com/eleybourn/bookcatalogue/BookEditFields.java
@@ -130,13 +130,15 @@ public class BookEditFields extends Activity {
 	protected ArrayList<String> getPublishers() {
 		ArrayList<String> publisher_list = new ArrayList<String>();
 		Cursor publisher_cur = mDbHelper.fetchAllPublishers();
-		startManagingCursor(publisher_cur);
-		while (publisher_cur.moveToNext()) {
-			String publisher = publisher_cur.getString(publisher_cur.getColumnIndexOrThrow(CatalogueDBAdapter.KEY_PUBLISHER));
-			publisher_list.add(publisher);
+		try {
+			while (publisher_cur.moveToNext()) {
+				String publisher = publisher_cur.getString(publisher_cur.getColumnIndexOrThrow(CatalogueDBAdapter.KEY_PUBLISHER));
+				publisher_list.add(publisher);
+			}
+			return publisher_list;
+		} finally {
+			publisher_cur.close();			
 		}
-		publisher_cur.close();
-		return publisher_list;
 	}
 
 	/**

--- a/src/com/eleybourn/bookcatalogue/BookEditNotes.java
+++ b/src/com/eleybourn/bookcatalogue/BookEditNotes.java
@@ -82,10 +82,13 @@ public class BookEditNotes extends Activity {
 	protected ArrayList<String> getLocations() {
 		ArrayList<String> location_list = new ArrayList<String>();
 		Cursor location_cur = mDbHelper.fetchAllLocations();
-		startManagingCursor(location_cur);
-		while (location_cur.moveToNext()) {
-			String publisher = location_cur.getString(location_cur.getColumnIndexOrThrow(CatalogueDBAdapter.KEY_LOCATION));
-			location_list.add(publisher);
+		try {
+			while (location_cur.moveToNext()) {
+				String publisher = location_cur.getString(location_cur.getColumnIndexOrThrow(CatalogueDBAdapter.KEY_LOCATION));
+				location_list.add(publisher);
+			}			
+		} finally {
+			location_cur.close();
 		}
 		return location_list;
 	}


### PR DESCRIPTION
It seems that Honeycomb releases cursors in Activitiy objects which
have been passed to startManagingObjects() but the underlying users of
those cursors (eg. intrinsic Android adapters) do not expect them to
be deleted.

This patch replaces startManagingCursor() functionality.

Unfortunately Google have not released Android 3.0 source yet, so it
is hard to tell the cause.
