### PR TITLE
Code cleanup

### DIFF
--- a/src/com/eleybourn/bookcatalogue/BookDetailsAbstract.java
+++ b/src/com/eleybourn/bookcatalogue/BookDetailsAbstract.java
@@ -33,6 +33,7 @@ import android.widget.Toast;
 
 import com.eleybourn.bookcatalogue.CoverBrowser.OnImageSelectedListener;
 import com.eleybourn.bookcatalogue.Fields.Field;
+import com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions;
 import com.eleybourn.bookcatalogue.cropper.CropCropImage;
 import com.eleybourn.bookcatalogue.debug.Tracker;
 import com.eleybourn.bookcatalogue.utils.HintManager;
@@ -702,8 +703,8 @@ public abstract class BookDetailsAbstract extends BookEditFragmentAbstract {
 		mFields.add(R.id.description, CatalogueDBAdapter.KEY_DESCRIPTION, null)
 			.setShowHtml(true);
 		mFields.add(R.id.genre, CatalogueDBAdapter.KEY_GENRE, null);
-		mFields.add(R.id.language, CatalogueDBAdapter.KEY_LANGUAGE, null);
-		
+		mFields.add(R.id.language, DatabaseDefinitions.DOM_LANGUAGE.name, null);
+
 		mFields.add(R.id.row_img, "", "thumbnail", null);
 		mFields.getField(R.id.row_img).getView().setOnCreateContextMenuListener(mCreateBookThumbContextMenuListener);
 		

--- a/src/com/eleybourn/bookcatalogue/BooksRowView.java
+++ b/src/com/eleybourn/bookcatalogue/BooksRowView.java
@@ -215,7 +215,7 @@ public class BooksRowView {
 	private int mLanguageCol = -2;
 	public final String getLanguage() {
 		if (mLanguageCol < 0) {
-			mLanguageCol = mCursor.getColumnIndex(CatalogueDBAdapter.KEY_LANGUAGE);
+			mLanguageCol = mCursor.getColumnIndex(DatabaseDefinitions.DOM_LANGUAGE.name);
 			if (mLanguageCol < 0)
 				throw new RuntimeException("LANGUAGE column not in result set");
 		}

--- a/src/com/eleybourn/bookcatalogue/CatalogueDBAdapter.java
+++ b/src/com/eleybourn/bookcatalogue/CatalogueDBAdapter.java
@@ -28,6 +28,7 @@ import static com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions.DOM_GENRE
 import static com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions.DOM_GOODREADS_BOOK_ID;
 import static com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions.DOM_ID;
 import static com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions.DOM_ISBN;
+import static com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions.DOM_LANGUAGE;
 import static com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions.DOM_LAST_GOODREADS_SYNC_DATE;
 import static com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions.DOM_LAST_UPDATE_DATE;
 import static com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions.DOM_LOCATION;
@@ -155,7 +156,6 @@ public class CatalogueDBAdapter {
 	public static final String KEY_READ_START = "read_start";
 	public static final String KEY_READ_END = "read_end";
 	public static final String KEY_FORMAT = "format";
-	public static final String KEY_LANGUAGE = "language";
 	public static final String OLD_KEY_AUDIOBOOK = "audiobook";
 	public static final String KEY_SIGNED = "signed";
 	public static final String KEY_DESCRIPTION = "description";
@@ -279,7 +279,7 @@ public class CatalogueDBAdapter {
 			KEY_SIGNED + " boolean not null default 0, " +
 			KEY_DESCRIPTION + " text, " +
 			KEY_GENRE + " text, " +
-			KEY_LANGUAGE + " text, " + // Added in version 82
+			DOM_LANGUAGE.getDefinition(true) + ", " + // Added in version 82
 			KEY_DATE_ADDED + " datetime default current_timestamp, " +
 			DOM_GOODREADS_BOOK_ID.getDefinition(true) + ", " +
 			DOM_LAST_GOODREADS_SYNC_DATE.getDefinition(true) + ", " +
@@ -581,7 +581,7 @@ public class CatalogueDBAdapter {
 			alias + "." + KEY_SIGNED + " as " + KEY_SIGNED + ", " + 
 			alias + "." + KEY_DESCRIPTION + " as " + KEY_DESCRIPTION + ", " + 
 			alias + "." + KEY_GENRE  + " as " + KEY_GENRE + ", " +
-			alias + "." + KEY_LANGUAGE  + " as " + KEY_LANGUAGE + ", " +
+			alias + "." + DOM_LANGUAGE  + " as " + DOM_LANGUAGE + ", " +
 			alias + "." + KEY_DATE_ADDED  + " as " + KEY_DATE_ADDED + ", " +
 			alias + "." + DOM_GOODREADS_BOOK_ID  + " as " + DOM_GOODREADS_BOOK_ID + ", " +
 			alias + "." + DOM_LAST_GOODREADS_SYNC_DATE  + " as " + DOM_LAST_GOODREADS_SYNC_DATE + ", " +
@@ -2717,9 +2717,9 @@ public class CatalogueDBAdapter {
 		String baseSql = fetchAllBooksInnerSql(null, bookshelf, "", "", "", "", "");
 
 		String sql = "SELECT DISTINCT "
-				+ " Case When (b." + KEY_LANGUAGE + " = '' or b." + KEY_LANGUAGE + " is NULL) Then ''"
-				+ " Else b." + KEY_LANGUAGE + " End as " + KEY_ROWID + baseSql +
-		" ORDER BY Upper(b." + KEY_LANGUAGE + ") " + COLLATION;
+				+ " Case When (b." + DOM_LANGUAGE + " = '' or b." + DOM_LANGUAGE + " is NULL) Then ''"
+				+ " Else b." + DOM_LANGUAGE + " End as " + KEY_ROWID + baseSql +
+		" ORDER BY Upper(b." + DOM_LANGUAGE + ") " + COLLATION;
 		return mDb.rawQuery(sql, new String[]{});
 	}
 	

--- a/src/com/eleybourn/bookcatalogue/FieldVisibility.java
+++ b/src/com/eleybourn/bookcatalogue/FieldVisibility.java
@@ -28,6 +28,7 @@ import android.view.View.OnClickListener;
 import android.widget.CheckBox;
 import android.widget.LinearLayout;
 
+import com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions;
 import com.eleybourn.bookcatalogue.compat.BookCatalogueActivity;
 import com.eleybourn.bookcatalogue.utils.Logger;
 import com.eleybourn.bookcatalogue.utils.Utils;
@@ -79,7 +80,7 @@ public class FieldVisibility extends BookCatalogueActivity {
 				CatalogueDBAdapter.KEY_RATING, CatalogueDBAdapter.KEY_NOTES, CatalogueDBAdapter.KEY_ANTHOLOGY_MASK, 
 				CatalogueDBAdapter.KEY_LOCATION, CatalogueDBAdapter.KEY_READ_START, CatalogueDBAdapter.KEY_READ_END, 
 				CatalogueDBAdapter.KEY_FORMAT, CatalogueDBAdapter.KEY_SIGNED, CatalogueDBAdapter.KEY_DESCRIPTION, 
-				CatalogueDBAdapter.KEY_GENRE, CatalogueDBAdapter.KEY_LANGUAGE};
+				CatalogueDBAdapter.KEY_GENRE, DatabaseDefinitions.DOM_LANGUAGE.name};
 		int[] fieldRs = {R.string.author, R.string.title, R.string.thumbnail, R.string.isbn, R.string.series, R.string.series_num, 
 				R.string.publisher, R.string.date_published, R.string.bookshelf, R.string.pages, R.string.list_price,
 				R.string.read, R.string.rating, R.string.notes, R.string.anthology, R.string.location_of_book, 

--- a/src/com/eleybourn/bookcatalogue/SearchAmazonHandler.java
+++ b/src/com/eleybourn/bookcatalogue/SearchAmazonHandler.java
@@ -26,6 +26,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import android.os.Bundle;
 
+import com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions;
 import com.eleybourn.bookcatalogue.utils.Logger;
 import com.eleybourn.bookcatalogue.utils.Utils;
 
@@ -334,7 +335,7 @@ public class SearchAmazonHandler extends DefaultHandler {
 				} else if (localName.equalsIgnoreCase(BINDING)){
 					addIfNotPresent(CatalogueDBAdapter.KEY_FORMAT);
 				} else if (mInLanguage && localName.equalsIgnoreCase(NAME)){
-					addIfNotPresent(CatalogueDBAdapter.KEY_LANGUAGE);
+					addIfNotPresent(DatabaseDefinitions.DOM_LANGUAGE.name);
 				} else if (mInListPrice && localName.equalsIgnoreCase(AMOUNT)){
 					mCurrencyAmount = mBuilder.toString();
 				} else if (mInListPrice && localName.equalsIgnoreCase(CURRENCY_CODE)){

--- a/src/com/eleybourn/bookcatalogue/UpdateFromInternet.java
+++ b/src/com/eleybourn/bookcatalogue/UpdateFromInternet.java
@@ -34,6 +34,7 @@ import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import com.eleybourn.bookcatalogue.UpdateFromInternet.FieldUsages.Usages;
+import com.eleybourn.bookcatalogue.booklist.DatabaseDefinitions;
 import com.eleybourn.bookcatalogue.debug.Tracker;
 import com.eleybourn.bookcatalogue.utils.Logger;
 import com.eleybourn.bookcatalogue.utils.Utils;
@@ -126,7 +127,7 @@ public class UpdateFromInternet extends ActivityWithTasks {
 		addIfVisible(CatalogueDBAdapter.KEY_FORMAT, null, R.string.format, Usages.COPY_IF_BLANK, false);
 		addIfVisible(CatalogueDBAdapter.KEY_DESCRIPTION, null, R.string.description, Usages.COPY_IF_BLANK, false);
 		addIfVisible(CatalogueDBAdapter.KEY_GENRE, null, R.string.genre, Usages.COPY_IF_BLANK, false);
-		addIfVisible(CatalogueDBAdapter.KEY_LANGUAGE, null, R.string.language, Usages.COPY_IF_BLANK, false);
+		addIfVisible(DatabaseDefinitions.DOM_LANGUAGE.name, null, R.string.language, Usages.COPY_IF_BLANK, false);
 
 		// Display the list of fields
 		LinearLayout parent = (LinearLayout) findViewById(R.id.manage_fields_scrollview);

--- a/src/com/eleybourn/bookcatalogue/backup/CsvExporter.java
+++ b/src/com/eleybourn/bookcatalogue/backup/CsvExporter.java
@@ -87,7 +87,7 @@ public class CsvExporter implements Exporter {
 			'"' + "anthology_titles" + "\"," +						//24 
 			'"' + CatalogueDBAdapter.KEY_DESCRIPTION+ "\"," + 		//25
 			'"' + CatalogueDBAdapter.KEY_GENRE+ "\"," + 			//26
-			'"' + CatalogueDBAdapter.KEY_LANGUAGE+ "\"," + 			//+1
+			'"' + DatabaseDefinitions.DOM_LANGUAGE+ "\"," + 			//+1
 			'"' + CatalogueDBAdapter.KEY_DATE_ADDED+ "\"," + 		//27
 			'"' + DatabaseDefinitions.DOM_GOODREADS_BOOK_ID + "\"," + 		//28
 			'"' + DatabaseDefinitions.DOM_LAST_GOODREADS_SYNC_DATE + "\"," + 		//29


### PR DESCRIPTION
Trying to use one source for data fields (but preserve legacy code),
the new Language field has been moved over to the DatabaseDefinitions
mode of doing things.
