### PR TITLE
Updated Spanish strings

### DIFF
--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -2,7 +2,7 @@
 <resources>
 
 	<string name="app_name">Book Catalogue</string>
-    <string name="system_app_name">Book Catalogue</string>
+    	<string name="system_app_name">Book Catalogue</string>
 	<string name="menu_insert">Añadir libro</string>
 	<string name="menu_delete">Eliminar libro</string>
 	<string name="author">Autor</string>
@@ -17,7 +17,7 @@
 	<string name="pages">Páginas</string>
 	<string name="confirm_add">Añadir libro</string>
 	<string name="confirm_update">Actualizar</string>
-	<string name="nobooks">No hay libros en esta biblioteca. Añade alguno utilizando el menú al pie de esta pantalla.</string>
+	<string name="nobooks">No hay libros en esta biblioteca. Añada alguno utilizando el menú al pie de esta pantalla.</string>
 	<string name="menu_sort_by_author_expanded">Expandir todo</string>
 	<string name="menu_sort_by">Ordenar por</string>
 	<string name="menu_sort_by_author_collapsed">Comprimir todo</string>
@@ -28,7 +28,7 @@
 	<string name="search">Buscar</string>
 	<string name="cancel">Cancelar</string>
 	<string name="confirm_save">Guardar libro</string>
-	<string name="nobookshelves">Todavía no has creado ninguna biblioteca. Crea una utilizando el menú al pie de esta pantalla.</string>
+	<string name="nobookshelves">Todavía no has creado ninguna biblioteca. Cree una utilizando el menú al pie de esta pantalla.</string>
 	<string name="menu_insert_bs">Crear biblioteca</string>
 	<string name="confirm_add_bs">Añadir biblioteca</string>
 	<string name="menu_bookshelf">Gestionar bibliotecas</string>
@@ -58,10 +58,10 @@
 	<string name="administration_label">Administración</string>
 	<string name="administration_title">Book Catalogue: Administración</string>
 	<string name="menu_administration">Admin</string>
-	<string name="install_scan">Para poder escanear códigos de barras de ISBN debe instalar la aplicación ZXING Barcode Scanner. Pulse Aceptar para instalarla, o Cancelar para salir.</string>
+	<string name="install_scan">Para poder escanear códigos de barras de ISBN debe instalar una aplicación de escaneo (Zxing o pic2shop). Seleccione una para instalarla, o Cancelar para salir.</string>
 	<string name="install_scan_title">Instalar Escáner de código de barras</string>
 	<string name="version_number">Versión</string>
-	<string name="donate">Si desea contribuir al desarrollo de esta aplicación puede realizar su aportación económica uilizando Amazon Wishlist o el botón de Paypal que figura más abajo. Al estar en Australia no puedo publicar una versión &quot;de pago&quot;. :-)</string>
+	<string name="donate">Si desea contribuir al desarrollo de esta aplicación puede realizar su aportación económica utilizando Amazon Wishlist o el botón de Paypal que figura más abajo. Al estar en Australia no puedo publicar una versión &quot;de pago&quot;. :-)</string>
 	<string name="unable_to_connect_amazon">No se ha podido conectar con Amazon</string>
 	<string name="upgrade_title">Desde la última actualización</string>
 	<string name="edit_book">Editar libro</string>
@@ -80,8 +80,8 @@
 	<string name="webpage">https://wiki.github.com/eleybourn/Book-Catalogue/</string>
 	<string name="sourcecode">https://github.com/eleybourn/Book-Catalogue</string>
 	<string name="helppage">https://github.com/eleybourn/Book-Catalogue/wiki/Help</string>
-    <string name="contact1">eleybourn@gmail.com</string>
-    <string name="contact2">philip.warner@rhyme.com.au</string>
+	<string name="contact1">eleybourn@gmail.com</string>
+	<string name="contact2">philip.warner@rhyme.com.au</string>
 	<string name="donate_label">Contribuir</string>
 	<string name="about_label">Acerca de esta App</string>
 	<string name="administration_functions_label">Funciones</string>
@@ -122,9 +122,9 @@
 	<string name="anthology_confirm">Por favor, confirme que los títulos de la antología son (en su mayoría) correctos</string>
 	<string name="anthology_save">Guardar</string>
 	<string name="anthology_add">Añadir</string>
-	<string name="menu_add_thumb_photo">Desde la cámara...</string>
+	<string name="menu_add_thumb_photo">Desde la cámara&#8230;</string>
 	<string name="thumbnail">Portada</string>
-	<string name="menu_rotate_thumb">Girar imagen...</string>
+	<string name="menu_rotate_thumb">Girar imagen&#8230;</string>
 	<string name="menu_rotate_thumb_cw">Sentido horario</string>
 	<string name="menu_rotate_thumb_ccw">Sentido antihorario</string>
 	<string name="menu_rotate_thumb_180">180 grados</string>
@@ -137,14 +137,14 @@
 	<string name="duplicate_title">Libro duplicado</string>
 	<string name="duplicate_book_title">Libro duplicado</string>
 	<string name="duplicate_book_message">El libro que intenta añadir ya está en la base de datos. ¿Desea añadir otra copia?</string>
-	<string name="menu_add_thumb_gallery">Desde la galería...</string>
+	<string name="menu_add_thumb_gallery">Desde la galería&#8230;</string>
 	<string name="backup_request">¿Desea realizar una copia de la base de datos a la tarjeta SD?</string>
 	<string name="backup_title">¿Realizar copia?</string>
 	<string name="searching_amazon_books">Buscando en Amazon</string>
 	<string name="searching_google_books">Buscando en Google Books</string>
 	<string name="searching_library_thing">Buscando en LibraryThing</string>
 	<string name="bookshelf_title">Marque las bibliotecas en las que quiere incluir este libro</string>
-    <string name="select_bookshelves">Seleccionar bibliotecas</string>
+	<string name="select_bookshelves">Seleccionar biblioteca</string>
 	<string name="format">Formato</string>
 	<string name="format1">Bolsillo</string>
 	<string name="format2">Tapa dura</string>
@@ -159,7 +159,7 @@
 	<string name="menu_search">Buscar libro</string>
 	<string name="menu_insert_name">Añadir por nombre</string>
 	<string name="isbn_name_search_help">Añadir libros con ISBN es mucho más preciso que hacerlo por autor y título. Recuerde que en ocasiones el código de barras o el ISBN se encuentran en la parte interior de la portada.\n\n</string>
-	<string name="help_click_here">Pulse aquí para acceder a las páginas de ayuda online</string>
+	<string name="help_click_here">Pulse aquí para acceder a la ayuda online</string>
 	<string name="backup_database">Copia de seguridad</string>
 	<string name="vldt_unable_to_get_value">Falta \'%s\'</string>
 	<string name="vldt_integer_expected">\'%s\' debe ser un entero</string>
@@ -182,16 +182,13 @@
 	<string name="noauthors">El libro no tiene autor. Añada alguno utilizando el campo de texto y el botón de la parte superior de esta pantalla.</string>
 	<string name="noseries">El libro no tiene serie. Puede especificar una utilizando el campo de texto y el botón de la parte superior de esta pantalla.</string>
 
-    <item name="TAG_POSITION" type="id"></item>
-    <item name="TAG_ORIGINAL_VALUE" type="id"></item>
-
 	<string name="cover_not_set">No hay imagen de portada</string>
 	<string name="cover_corrupt">La imagen de portada está dañada</string>
 	<string name="cover_detail">Portada</string>
 	<string name="select_picture">Seleccionar imagen</string>
-	<string name="set_authors">Definir autores...</string>
+	<string name="set_authors">Definir autores&#8230;</string>
 	<string name="and_others">et. al.</string>
-	<string name="set_series">Definir serie...</string>
+	<string name="set_series">Definir serie&#8230;</string>
 	<string name="author_already_in_list">Ese autor ya está en la lista</string>
 	<string name="author_is_blank">El campo Autor está en blanco</string>
 	<string name="series_already_in_list">Esa serie ya está en la lista</string>
@@ -206,13 +203,13 @@
 	<string name="given_names">Nombre</string>
 	<string name="edit_author_details">Modificar autor</string>
 	<string name="immediate_global_changes">NOTA: Todos los cambios guardados se aplican de manera instantánea y global</string>
-	<string name="menu_replace_thumb">Cambiar portada...</string>
-	<string name="menu_thumb_alt_editions">De otras ediciones...</string>
+	<string name="menu_replace_thumb">Cambiar portada&#8230;</string>
+	<string name="menu_thumb_alt_editions">De otras ediciones&#8230;</string>
 	<string name="author_required">Se debe especificar al menos un autor</string>
 	<string name="title_required">El título no puede estar en blanco</string>
-	<string name="menu_delete_series">Eliminar serie...</string>
-	<string name="menu_edit_author">Modificar autor...</string>
-	<string name="menu_edit_series">Modificar serie...</string>
+	<string name="menu_delete_series">Eliminar serie&#8230;</string>
+	<string name="menu_edit_author">Modificar autor&#8230;</string>
+	<string name="menu_edit_series">Modificar serie&#8230;</string>
 	<string name="delete_series">Eliminar serie</string>
 	<string name="really_delete_series">Confirme la eliminación de la serie \'%s\'\n\nLos libros no se eliminarán.\n\nConsidere la opción de editar la serie para cambiar el nombre, para conservar los datos</string>
 	<string name="edit_series">Modificar serie</string>
@@ -227,15 +224,13 @@
 	<string name="changed_series_how_apply">Ha cambiado la serie de:\n  \'%1$s\' a \n  \'%2$s\'\n¿Cómo quiere aplicar este cambio?\nNota: La opción \'All Books\' se aplicará de manera inmediata.</string>
 	<string name="unable_to_find_book">No se ha encontrado el libro especificado</string>
 	<string name="list_and">y</string>
-	<string name="really_delete_book">Se dispone a eliminar el libro titulado \'%1$s\' de %2$s. ¿Está seguro de que desea continuar?</string>
+	<string name="really_delete_book">Se dispone a eliminar el libro con el título \'%1$s\' de %2$s. ¿Está seguro de que desea continuar?</string>
 	<string name="editions_require_isbn">Para obtener otras ediciones es necesario el ISBN</string>
 	<string name="no_editions">No hay más ediciones</string>
-	<string name="finding_editions">Buscando ediciones...</string>
+	<string name="finding_editions">Buscando ediciones&#8230;</string>
 	<string name="click_on_thumb">Pinche sobre una portada para ver una imagen de mayor tamaño</string>
-	<string name="loading">Cargando...</string>
+	<string name="loading">Cargando&#8230;</string>
 	<string name="image_not_found">Imagen no encontrada</string>
-
-    <item name="fieldCheckbox" type="id"></item>
 
 	<string name="select_min_1_field">Seleccione al menos un campo para actualizar</string>
 	<string name="usage_copy_if_blank">Copiar si está en blanco</string>
@@ -256,10 +251,10 @@
 	<string name="disable_dialogue">Deshabilitar mensaje</string>
 	<string name="lt_reset_messages_info">Esta aplicación puede mostrar, de vez en cuando, mensajes relacionados con LibraryThing. Pulse el botón siguiente para resetear cualquiera de los mensajes que hayan sido deshabilitados.</string>
 	<string name="reset">Reiniciar</string>
-	<string name="send_info_text">Pulse el botón siguiente para recopilar información sobre cualquier fallo reciente y enviarlo al equipo de desarrollo. Se creará una copia de seguridad de su base de datos y de los archivos de registro. Si no desea enviar ninguno de estos ficheros, elimine los correspondientes ficheros adjuntos antes de enviar el correo que se generará.</string>
+	<string name="send_info_text">Pulse el botón siguiente para recopilar información sobre cualquier fallo reciente y enviarlo al equipo de desarrollo. Se creará una copia de seguridad de su base de datos y de los archivos de registro. Si no desea enviar alguno de estos ficheros, elimine los correspondientes adjuntos antes de enviar el correo que se generará.</string>
 	<string name="send_info">Enviar información</string>
-	<string name="cleanup_files_text">Los ficheros que se pueden eliminar ocupan %s en la tarjeta SD. Cada vez que se actualiza la versión de BookCatalogue, al hacer una copia de seguridad o cuando falla la aplicación se crean ficheros de registro en la tarjeta SD. Pulse el botón siguiente para eliminarlos. Si ha detectado algún error, le agradeceremos que utilice primero la opción de \'send_info\'.</string>
-	<string name="cleanup_files">Borrando ficheros</string>
+	<string name="cleanup_files_text">Los ficheros que se pueden eliminar ocupan %s en la tarjeta SD. Cada vez que se actualiza la versión de BookCatalogue, al hacer una copia de seguridad o cuando falla la aplicación se crean ficheros de registro en la tarjeta SD. Pulse el botón siguiente para eliminarlos. Si ha detectado algún error, le agradeceremos que utilice primero la opción de \'Enviar información\'.</string>
+	<string name="cleanup_files">Borrar ficheros</string>
 	<string name="no_debug_info">No se ha encontrado información sobre fallos</string>
 	<string name="megabytes">%.2fMB</string>
 	<string name="kilobytes">%.2fkB</string>
@@ -276,7 +271,7 @@
     <string name="no_connection">No hay conexión a internet.</string>
     <string name="sortby_published">Ordenar por fecha de publicación</string>
     <string name="menu_share_this">Compartir</string>
-    <string name="email_export">¿Desea enviar esta exportación por correo electrónico?</string>
+    <string name="email_export">¿Desea enviar por correo electrónico el fichero exportado?</string>
     <string name="menu_crop_thumb">Recortar miniatura</string>
     <string name="test_goodreads">Comprobar Goodreads</string>
     <string name="task_errors">Errores en tareas</string>
@@ -287,15 +282,6 @@
     <string name="visit_goodreads">Visitar GoodReads&#8230;</string>
     <string name="delete_event">Eliminar Evento</string>
     <string name="delete_task">Eliminar Tarea</string>
-
-    <item name="TAG_EVENT" type="id"></item>
-    <item name="TAG_HOLDER" type="id"></item>
-    <item name="TAG_TASK" type="id"></item>
-    <item name="TAG_TASK_ID" type="id"></item>
-    <item name="TAG_BOOK_EVENT_HOLDER" type="id"></item>
-    <item name="TAG_TASK_HOLDER" type="id"></item>
-    <item name="TAG_PROPERTY" type="id"></item>
-    <item name="TAG_DIALOG_ITEM" type="id"></item>
 
     <string name="my_books">Mis Libros</string>
     <string name="my_books_classic">Mis Libros (Clásico)</string>
@@ -321,9 +307,9 @@
     <string name="goodreads_access_error">Se ha producido un problema de red al acceder a goodreads. Compruebe si el sitio web de goodreads está operativo, y si el problema persiste póngase en contacto con su servicio de soporte</string>
     <string name="other_preferences">Otras preferencias</string>
     <string name="user_interface">Interfaz de usuario</string>
-    <string name="start_in_my_books">Empezar en \'My Books\'</string>
+    <string name="start_in_my_books">Empezar en \'Mis libros\'</string>
     <string name="include_classic_catalogue_view">Incluir vista clásica del Catálogo</string>
-    <string name="background_tasks">Tareas de fondo</string>
+    <string name="background_tasks">Tareas en segundo plano</string>
     <string name="cleanup_old_tasks">Eliminar tareas antiguas</string>
     <string name="cleanup_old_events">Eliminar eventos antiguos</string>
     <string name="show_more">Mostrar más</string>
@@ -338,10 +324,10 @@
     <string name="search_in">Buscar en</string>
     <string name="send_books_to_goodreads">Enviar libros a goodreads</string>
     <string name="legacy_task">Legacy Task</string>
-    <string name="occurred_at">occurred at %1$s</string>
+    <string name="occurred_at">ocurrido en %1$s</string>
     <string name="unknown_uc">DESCONOCIDO</string>
     <string name="this_book_deleted_uc">ESTE LIBRO HA SIDO ELIMINADO</string>
-    <string name="by">by %1$s</string>
+    <string name="by">por %1$s</string>
     <string name="no_matching_book_found">No se ha encontrado ningún libro</string>
     <string name="no_isbn_stored_for_book">No se ha guardado ISBN para el libro</string>
     <string name="select_an_action">Seleccione una opción</string>
@@ -360,17 +346,13 @@
     <string name="x_of_y">%1$s de %2$s</string>
     <string name="send_book_to_goodreads">Enviar libro %1$s a goodreads</string>
 
-    <item name="NOTIFICATION" type="id"></item>
-    <item name="TAG_GOODREADS_WORK" type="id"></item>
-    <item name="TAG_GET_THUMBNAIL_TASK" type="id"></item>
-
     <string name="erase_cover_cache">Borrar caché de portadas</string>
-    <string name="crash_toast_text">BookCatalogue se ha detenido de forma inesperada. Por favor, ayúdenos a hacer mejor la aplicación reportando este problema.</string>
+    <string name="crash_toast_text">BookCatalogue se ha detenido de forma inesperada. Por favor, ayúdenos a mejorar la aplicación reportando este problema.</string>
     <string name="crash_notif_ticker_text">BookCatalogue se ha detenido</string>
     <string name="crash_notif_title">Error de BookCatalogue</string>
     <string name="crash_notif_text">Pulse para ver más detalles</string>
     <string name="crash_dialog_title">Error de BookCatalogue</string>
-    <string name="crash_dialog_text">Parece que BookCatalogue se ha detenido. Si es posible, indique cualquier detalle que usted considere relevante y pulse "OK" para enviarnos un correo electrónico sobre el problema. Podrá revisar el correo antes de que se envíe.</string>
+    <string name="crash_dialog_text">Parece que BookCatalogue se ha detenido. Si es posible, indique cualquier detalle que usted considere relevante y pulse OK para enviarnos un correo electrónico sobre el problema. Podrá revisar el correo antes de que se envíe.</string>
     <string name="crash_dialog_comment_prompt">Sus comentarios (puede dejarlos en blanco):</string>
     <string name="crash_dialog_ok_toast">¡Muchas gracias!</string>
     <string name="browse_books">Ver todos los libros</string>
@@ -401,24 +383,11 @@
     <string name="empty_with_brackets">(vacío)</string>
     <string name="navigator">Navegador</string>
 
-    <item name="MENU_DELETE_BOOK" type="id"/>
-    <item name="MENU_EDIT_BOOK" type="id"/>
-    <item name="MENU_EDIT_BOOK_NOTES" type="id"/>
-    <item name="MENU_EDIT_BOOK_FRIENDS" type="id"/>
-    <item name="MENU_SEND_BOOK_TO_GR" type="id"/>
-    <item name="MENU_EDIT_AUTHOR" type="id"/>
-    <item name="MENU_EDIT_FORMAT" type="id"/>
-    <item name="MENU_DELETE_SERIES" type="id"/>
-    <item name="MENU_EDIT_SERIES" type="id"/>
-    <item name="MENU_DELETE_STYLE" type="id"/>
-    <item name="MENU_EDIT_STYLE" type="id"/>
-    <item name="MENU_CLONE_STYLE" type="id"/>
-
     <string name="booklist_preferences">Preferencias para la lista de libros</string>
     <string name="extra_book_details">Detalles adicionales</string>
     <string name="general">General</string>
-    <string name="bookshelves">Bibliotecas</string>
-    <string name="shelves">Estantes</string>
+    <string name="bookshelves">Biblioteca</string>
+    <string name="shelves">Biblioteca</string>
     <string name="location">Ubicación</string>
     <string name="management">Gestión</string>
     <string name="credentials">Credenciales</string>
@@ -437,8 +406,8 @@
     <string name="show_more_ellipsis">Mostrar más&#8230;</string>
     <string name="show_fewer_ellipsis">Mostrar menos&#8230;</string>
     <string name="customize_ellipsis">Configurar&#8230;</string>
-    <string name="hint">Truco</string>
-    <string name="reset_hints">Resetear trucos</string>
+    <string name="hint">Sugerencia</string>
+    <string name="reset_hints">Resetear sugerencias</string>
     <string name="do_not_show_again">No volver a mostrar</string>
     <string name="other_settings_ellipsis">Otras configuraciones&#8230;</string>
     <string name="hint_booklist_styles_editor">Puede utilizar esta opción para configurar la lista de estilos que se mostrarán en su menú de estilos. 
@@ -447,22 +416,26 @@
     										\n\nSi no se marca ningún estilo, se mostrarán todos.
     										\n\nEs posible reordenar los elementos arrastrando el icono del extremo derecho de cada fila.
     										\n\nHaciendo clic en cualquier otro sitio de la línea podrá editar los detalles de un estilo específico 
-    										(o copiarlo, si es un estilo predefinido).</string>
+    										(o copiarlo, si es un estilo predefinido).
+</string>
     <string name="hint_booklist_style_groups">Puede utilizar esta opción para modificar la jerarquía de las cabeceras para un determinado estilo de listado.
     										\n\nUna marca verde indica que el encabezado se mostrará en la lista, un aspa roja indica que no se mostrará.
     										Al hacer clic sobre una marca verde se convierte en un aspa roja, y viceversa.
-    										\n\nPuede reordenar la jerarquía arrastrando el icono del extremo derecho de cada fila hacia arriba o hacia abajo.</string>
+    										\n\nPuede reordenar la jerarquía arrastrando el icono del extremo derecho de cada fila hacia arriba o hacia abajo.
+</string>
     <string name="hint_booklist_style_properties">Puede utilizar esta opción para configurar las características de un determinado estilo de listado.
     										\n\nPuede cambiar el nombre, editar los grupos para cambiar la jerarquía y modificar otros parámetros para
     										configurar un estilo que le resulte útil.
     										\n\nTambién se pueden utilizar \'Book Filters\' para modificar la selección de libros que se mostrarán en
-    										el listado, por ejemplo, para mostrar únicamente libros no leídos.</string>
+    										el listado, por ejemplo, para mostrar únicamente libros no leídos.
+</string>
     <string name="hint_booklist_global_properties">Puede utilizar esta opción para configurar las características por defecto de todos los estilos de listados de libros.
     										\n\nLa mayoría de las propiedades se pueden modificar para cada estilo individual, pero los valores por defecto se
     										definen aquí.
     										\n\nPuede cambiar el fondo, la forma en que los listados se muestran al arrancar, y modificar otros parámetros
     										que se aplicarán a todos sus estilos cuando sea posible.
-    										\n\nTambién puede editar desde aquí el menú de estilos, y los propios estilos.</string>
+    										\n\nTambién puede editar desde aquí el menú de estilos, y los propios estilos.
+</string>
     <string name="preferred_styles">Estilos preferidos</string>
     <string name="edit_style_colon_name">Editar estilo: %1$s</string>
     <string name="add_style">Añadir estilo</string>
@@ -476,11 +449,11 @@
     <string name="books_with_multiple_authors">Libros con varios autores</string>
     <string name="books_in_multiple_series">Libros en varias series</string>
     <string name="use_default_setting">Utilizar configuración por defecto</string>
-    <string name="show_book_under_each_thing">Under each %1$s</string>
+    <string name="show_book_under_each_thing">Bajo cada %1$s</string>
     <string name="show_book_under_primary_thing">Sólo bajo %1$s primarios</string>
     <string name="format_of_author_names">Formato para nombres de autor</string>
-    <string name="given_name_first_eg">Nombre primero, por ejemplo \'Bill Smith\'</string>
-    <string name="family_name_first_eg">Apellido primero, por ejemplo \'Smith, Bill\'</string>
+    <string name="given_name_first_eg">Nombre primero, por ejemplo \'Antonio García\'</string>
+    <string name="family_name_first_eg">Apellido primero, por ejemplo \'García, Antonio\'</string>
     <string name="thumbnails">Miniaturas</string>
     <string name="size_of_booklist_items">Tamaño de los elementos en el listado</string>
     <string name="normal">Normal</string>
@@ -510,7 +483,7 @@
     <string name="export_task_is_already_queued">Ya hay una tarea de exportación pendiente, y debe completarse antes de que se pueda lanzar de nuevo</string>
     <string name="import_task_is_already_queued">Ya hay una tarea de importación pendiente, y debe completarse antes de que se pueda lanzar de nuevo</string>
     <string name="goodreads_action_cannot_blah_blah">Esta acción no se puede completar mientras la aplicación no sea autorizada en el sitio web goodreads web site. Inténtelo una vez haya autorizado esta aplicación. \n\nQuiere autorizarla ahora?</string>
-    <string name="tell_me_more">Cuénteme más</string>
+    <string name="tell_me_more">Cuéntenos más</string>
     <string name="retry_x_of_y_next_at_z">Reintento %1$s de %2$s, el próximo a las %3$s</string>
     <string name="completed">Completado</string>
     <string name="failed">Fallido</string>
@@ -530,12 +503,12 @@
     <string name="hint_authors_book_may_appear_more_than_once">Si se muestra para cada autor, un mismo libro puede aparecer más de una vez en un listado. En ese caso, si se elimina uno de esos libros se eliminará de todas las posiciones del listado.</string>
     <string name="hint_series_book_may_appear_more_than_once">Si se muestra en cada serie, un mismo libro puede aparecer más de una vez en un listado. En ese caso, si se elimina uno de esos libros se eliminará de todas las posiciones del listado.</string>
     <string name="hint_background_tasks">Aquí puede ver las tareas que se están ejecutando, así como las que ya se han completado con errores o con otro tipo de incidencias. 
-    								Haciendo clic sobre una tarea podrá ver los eventos asociados, o borrar la tarea (no los eventos).</string>
-    <string name="hint_background_task_events">Aquí puede ver los eventos asociados con una tarea de fondo. 
+    								Haciendo clic sobre una tarea podrá ver los eventos asociados, o borrar la tarea (y los eventos).</string>
+    <string name="hint_background_task_events">Aquí puede ver los eventos asociados con una tarea en segundo plano. 
     								Haciendo clic sobre un evento podrá realizar distintas acciones según el tipo de evento.</string>
-    <string name="hints_have_been_reset">Trucos reseteados</string>
-    <string name="task_has_been_queued_in_background">Tarea añadida a la cola de fondo</string>
-    <string name="hint_startup_screen">Esta es la pantalla estándar de inicio de BookCatalogue. Si lo prefiere, puede arrancar directamente en \'My Books\'; la pantalla de arranque preferida puede cambiarse en preferencias.</string>
+    <string name="hints_have_been_reset">Sugerencias reseteadas</string>
+    <string name="task_has_been_queued_in_background">Tarea añadida a la cola de tareas en segundo plano</string>
+    <string name="hint_startup_screen">Esta es la pantalla estándar de inicio de BookCatalogue. Si lo prefiere, puede iniciar la aplicación directamente en \'Mis Libros\'; la pantalla de inicio preferida puede cambiarse en preferencias.</string>
     <string name="upgrading_ellipsis">Actualizando&#8230;</string>
     <string name="explain_goodreads_no_isbn">El libro seleccionado no tiene ISBN; no se puede sincronizar de forma automática con goodreads. 
     									Para solucionarlo puede:
@@ -564,7 +537,7 @@
     <string name="no_export_files_found">No se han encontrado archivos exportados</string>
     <string name="more_than_one_export_file_blah">Se ha encontrado más de un archivo exportado; por favor, seleccione el archivo que desea importar de la lista siguiente</string>
     <string name="problem_starting_import_arg">Ha habido un problema con la importación: %1$s</string>
-    <string name="hint_booklist_style_menu">Esta opción le permite seleccionar el estilo del listado. 
+    <string name="hint_booklist_style_menu">Esta opción le permite seleccionar el estilo de los listados. 
     								\n\nTambién puede modificar este menú, así como crear sus propios estilos de listado, seleccionando \'Customize\' al final de la lista.</string>
     <string name="menu_edit_format">Editar Formato&#8230;</string>
     <string name="edit_format_name">Editar Nombre del Formato</string>
@@ -621,7 +594,7 @@
     <string name="hint_autorotate_camera_images">Si siempre tiene que girar las imágenes de la cámara en el mismo sentido, intente cambiar la configuración para aplicar la rotación automática.</string>
     <string name="default_crop_frame_is_whole_image">Por defecto, la imagen se guarda completa</string>
     <string name="cancelled">Cancelado</string>
-    <string name="import_complete">Importación completada</string>
+    <string name="import_complete">Importación finalizada</string>
     <string name="amazon_books">Amazon</string>
     <string name="google_books">Google Books</string>
     <string name="library_thing">LibraryThing</string>
@@ -635,7 +608,7 @@
     <string name="brackets">(%1$s)</string>
     <string name="new_in_42">
 <![CDATA[
-    <p><b>New in 4.2</b>\n\n
+    <p><b>Novedades en la versión 4.2</b>\n\n
 			* Introducción de fecha que soporta fechas desde 0AD así como fechas parciales\n\n
 			* Las descripciones HTML se muestran correctamente al hacer clic para editar\n\n
 			* Opción para pre-seleccionar la imagen completa al recortar\n\n
@@ -645,44 +618,44 @@
 			* Actualización de la traducción al francés (Imkal)\n\n
 			* Actualización de la traducción al alemán (Robert Wetzlmayr)\n\n
 			* Actualización de la traducción al ruso (Nick Silin)\n\n
-			* Cambios en la posición de los botones OK/Cancelar, para adaptarlos al actual estándar de Android\n\n
+			* Cambios en la posición de los botones Aceptar/Cancelar, para adaptarlos al actual estándar de Android\n\n
 			* Teclado completo disponible al introducir ASINs\n\n
-			* Se mantienen los últimos 5 archivos exportados\n\n
-			* Mejoras en la detección de \'changes\' al editar libros\n\n
+			* Se mantienen los 5 últimos archivos exportados\n\n
+			* Mejoras en la detección de \'cambios\' al editar libros\n\n
 			* Soporte para más Galerías y Exploradores de archivos\n\n
 			* Más fiabilidad en la gestión de fechas de importación/exportación/sincronización\n\n
 			* Corrección en la gestión de títulos duplicados de antologías\n\n
 			* Corrección de otros pequeños errores\n\n
 			Muchas gracias a nuestros beta-testers y traductores!\n\n
-			Gracias a Grunthos por todos los errores reportados. Y enviadnos vuestros informes de errores.
+			Gracias a Grunthos por todos los errores reportados. Enviadnos por favor vuestros informes de errores.
 			</p>
 		]]>
     </string>
     <string name="_empty_"></string>
     <string name="new_in_421">
 <![CDATA[
-    <p><b>New in 4.2.1</b>\n\n
-			* Corregido error cuando se expandía la lista utilizando \'Expand All\'\n\n
+    <p><b>Novedades en la versión 4.2.1</b>\n\n
+			* Corregido error cuando se expandía la lista utilizando \'Expandir todo\'\n\n
 			</p>
 		]]>
     </string>
-    <string name="bad_scanner">Su aplicación de escaneado de código de barras no es compatibles con Book Catalogue. Recomendamos la instalción de Zxing barcode scanner, y si ya está instalada, pruebe a desinstalarla y volver a instalarla.</string>
+    <string name="bad_scanner">Su aplicación de escaneado de código de barras no es compatible con Book Catalogue. Recomendamos la instalción de Zxing barcode scanner, y si ya está instalada, pruebe a desinstalarla y volver a instalarla.</string>
     <string name="new_in_422">
 <![CDATA[
-    <p><b>New in 4.2.2</b>\n\n
+    <p><b>Novedades en la versión 4.2.2</b>\n\n
 			* Corrección en la gestión de la imagen de fondo para ciertas versiones de Android\n\n
 			* Mejoras en la gestión de aplicaciones de escaneado no compatibles\n\n
 			* Envío de más detalles de errores, o al solicitar ayuda\n\n
-			* Simplificación de layouts (Nick Silin)\n\n
+			* Simplificación de pantallas (Nick Silin)\n\n
 			* Corrección de otros errores\n\n
 			</p>
 		]]>
     </string>
     <string name="new_in_423">
 <![CDATA[
-    <p><b>New in 4.2.3</b>\n\n
+    <p><b>Novedades en la versión 4.2.3</b>\n\n
 			* Mejoras en la gestión de ISBNs no válidos al enviar a goodreads\n\n
-			* Corrección de otros errores menores\n\n
+			* Corrección de otros pequeños errores\n\n
 			</p>
 		]]>
     </string>
@@ -696,11 +669,11 @@
     <!-- Preference VALUE, displayed in a preference activity -->
     <string name="pic2shop_scanner">Pic2Shop Scanner</string>
     <!-- Preference name, displayed in a preference activity -->
-    <string name="beep_if_scanned_isbn_valid">Pitar si el ISBN escaneado no es válido</string>
+    <string name="beep_if_scanned_isbn_valid">Pitido si el ISBN escaneado es válido</string>
     <string name="new_in_424">
 <![CDATA[
-	<p><b>New in 4.2.4</b>\n\n
-		* Vista no editable de los detalles de un libro, con soporte \'fling\'! (Ver \"Other Preferences\") (Nick Silin)\n\n
+	<p><b>Novedades en la versión 4.2.4</b>\n\n
+		* Vista no editable de los detalles de un libro, con soporte \'fling\'! (Ver \"Otras preferencias\") (Nick Silin)\n\n
 		* Soporte para el escáner pic2shop (mejor para foco fijo, poca luz y cámaras frontales)\n\n
 		* Comprobación de la conexión a internet al tratar de escanear libros\n\n
 		* Actualización de la traducción al alemán (Robert Wetzlmayr)\n\n
@@ -712,11 +685,13 @@
 
     <!-- Hint text displayed when user enters the book listw -->
     <string name="hint_view_only_book_details">Al pulsar sobre un elemento de esta lista, puede seleccionar la opción de ir a una vista no editable con los detalles del libro. 
-Vea "Otras preferencias" para configurarlo.</string>
+Vea "Otras preferencias" para configurarlo.
+</string>
 
     <!-- Hint text displayed when user enters the 'read-only' book view -->
     <string name="hint_view_only_help">Esta es la vista no editable de la pantalla de detalles. Puede deslizar la pantalla a derecha o izquierda para ver otros libros, 
-y puede editar el libro utilizando el menú de opciones.</string>
+y puede editar el libro utilizando el menú de opciones.
+</string>
 
     <!-- This is the heading of the 'Details' tab when editing a book. It needs to be short. "Book Details" is too long. -->
     <string name="details">Detalles</string>
@@ -727,14 +702,14 @@ y puede editar el libro utilizando el menú de opciones.</string>
     <string name="hint_not_a_full_backup">Por favor, tenga en cuenta que esta no es una copia de seguridad. No incluye las imágenes de las portadas.
     	\n\nPara realizar una copia de seguridad completa, es necesario copiar el contenido del directorio \'bookCatalogue\'
     	de su tarjeta SD a otra ubicación.
-    	\n\nVea nuestras Preguntas frecuentas (FAQ) con las instrucciones detalladas para hacerlo (enlace a la web disponible en \'Help\').</string>
+    	\n\nVea nuestras Preguntas frecuentas (FAQ) con las instrucciones detalladas para hacerlo (enlace a la web disponible en \'Ayuda\').</string>
 
     <!-- Button text on the goodreads activity; only displayed after user has registered -->
     <string name="forget_credentials">Olvidar credenciales</string>
 
     <!-- Extra text displayed on the goodreads activity when a user HAS registered -->
     <string name="goodreads_auth_blurb_part4">Parece que ya ha autorizado esta aplicación. Si quiere
-    eliminar los datos de acceso (credenciales) de este teléfono, puede hacerlo pulsando el botón siguiente. También es
+    eliminar los datos de acceso (credenciales) de este dispositivo, puede hacerlo pulsando el botón siguiente. También es
     importante que elimine la autorización para esta aplicación en el sitio web de goodreads.
     \n\nAl eliminar las credenciales se eliminará la opción goodreads del menú principal de la aplicación.</string>
 
@@ -742,9 +717,9 @@ y puede editar el libro utilizando el menú de opciones.</string>
     <string name="connecting_to_web_site">Conectando con el sitio web&#8230;</string>
 
     <!-- Admin option to import -->
-    <string name="backup_to_archive">Backup a Archivo</string>
+    <string name="backup_to_archive">Backup a Fichero</string>
     <!-- Admin option to import -->
-    <string name="import_from_archive">Importar de Archivo</string>
+    <string name="import_from_archive">Importar de Fichero</string>
 
     <!-- Hint displayed when aCatalogue Backup is done -->
     <string name="archive_complete_details">Se ha creado un fichero de %3$s llamado %2$s en el directorio \"%1$s\" de su tarjeta SD.
@@ -755,7 +730,7 @@ y puede editar el libro utilizando el menú de opciones.</string>
     <!-- Heading in Admin activity -->
     <string name="advanced_options">Opciones avanzadas</string>
     <!-- Showed in progress dialog when an import starts -->
-    <string name="backing_up_ellipsis">Backing up&#8230;</string>
+    <string name="backing_up_ellipsis">Copiando&#8230;</string>
     <!-- Showed in progress dialog when an import starts -->
     <string name="importing_ellipsis">Importando&#8230;</string>
 
@@ -774,21 +749,21 @@ y puede editar el libro utilizando el menú de opciones.</string>
     <string name="import_from_csv">Importar de fichero CSV</string>
 
     <!-- Displayed when a file/open dialog results in selecting a non-exitant file -->
-    <string name="please_select_an_existing_file">Por favor, seleccione un archivo</string>
+    <string name="please_select_an_existing_file">Por favor, seleccione un fichero</string>
 
     <!-- Displayed when a file/save dialog results in selecting a directory file -->
-    <string name="please_select_a_non_directory">Por favor, seleccione un archivo, no un directorio</string>
+    <string name="please_select_a_non_directory">Por favor, seleccione un fichero, no un directorio</string>
 
     <!-- This is pretty close to the expected feature list! It is a merge of 424 and 430... -->
     <string name="new_in_500">
 <![CDATA[
-	<p><b>New in 5.0.0</b>\n\n
-		* Vista no editable de los detalles de un libro, con soporte \'fling\'! (Ver \"Other Preferences\") (Nick Silin)\n\n
+	<p><b>Novedades en la versión 5.0.0</b>\n\n
+		* Vista no editable de los detalles de un libro, con soporte \'fling\'! (Ver \"Otras preferencias\") (Nick Silin)\n\n
 		* Archivado (Backup & Importación) del catálogo completo, incluyendo libros, portadas, preferencias y estilos\n\n
 		* Interfaz actualizada con una barra de acción que funciona mejor en dispositivos sin botones de menú\n\n
 		* Soporte para el escáner pic2shop (mejor para foco fijo, poca luz y cámaras frontales)\n\n
 		* goodreads aparece ahora en el menú principal, si lo autoriza\n\n
-		* Comprobar conexión a internet antes a tratar de escanear libros\n\n
+		* Comprobar conexión a internet antes de intentar escanear libros\n\n
 		* Más actualizaciones en la traducción al alemán (Robert Wetzlmayr)\n\n
 		* Más actualizaciones en la traducción al francés (Imkal & Djiko)\n\n
 		* Más actualizaciones en la traducción al ruso (Nick Silin)\n\n
@@ -817,7 +792,7 @@ y puede editar el libro utilizando el menú de opciones.</string>
 
     <string name="new_in_502">
 		<![CDATA[
-			<p><b>New in 5.0.2</b>\n\n
+			<p><b>Novedades en la versión 5.0.2</b>\n\n
 				* Corrección de errores\n\n
 			</p>
 		]]>
@@ -829,7 +804,7 @@ y puede editar el libro utilizando el menú de opciones.</string>
 
     <string name="new_in_503">
 		<![CDATA[
-			<p><b>New in 5.0.3</b>\n\n
+			<p><b>Novedades en la versión 5.0.3</b>\n\n
 				* Corrección de errores\n\n
 				* Actualización de la traducción al francés (Imkal)\n\n
 			</p>
@@ -844,7 +819,7 @@ y puede editar el libro utilizando el menú de opciones.</string>
     <string name="language">Idioma</string>
     <string name="new_in_504">
 		<![CDATA[
-			<p><b>New in 5.0.4</b>\n\n
+			<p><b>Novedades en la versión 5.0.4</b>\n\n
 				* Nuevo campo: Idioma\n\n
 				* Actualización de la traducción al francés (Imkal)\n\n
 				* Corrección de errores\n\n
@@ -868,7 +843,7 @@ y puede editar el libro utilizando el menú de opciones.</string>
     
     <string name="new_in_505">
 		<![CDATA[
-			<p><b>New in 5.0.5</b>\n\n
+			<p><b>Novedades en la versión 5.0.5</b>\n\n
 				* Se puede ordenar por "Fecha de inclusión", inversa\n\n
 				* Actualización de la traducción al francés (Imkal)\n\n
 				* Corrección de errores\n\n
@@ -881,7 +856,7 @@ y puede editar el libro utilizando el menú de opciones.</string>
     <!-- Begin: Added/Updated in 5.0.8 -->
     <string name="new_in_508">
 		<![CDATA[
-			<p><b>New in 5.0.8</b>\n\n
+			<p><b>Novedades en la versión 5.0.8</b>\n\n
 				* Actualización de la traducción al alemán (Robert Wetzlmayr)\n\n
 			</p>
 		]]>
@@ -889,34 +864,140 @@ y puede editar el libro utilizando el menú de opciones.</string>
     <!-- End: Added/Updated in 5.0.8 -->
 
 	<!--  Note to Translators: don't bother translating strings until they get a version number. They are very much 'draft' versions -->
+    
+    <!-- Begin: Added/Updated in 5.0.9 -->
+    <string name="new_in_509">
+		<![CDATA[
+			<p><b>Novedades en la versión 5.0.9</b>\n\n
+				* Corrección de errores para Android 4.4 (KitKat)\n\n
+				* Actualización de la traducción al alemán (Gideon van Melle)\n\n
+				* Corrección de otros pequeños errores
+			</p>
+		]]>
+    </string>
 
-    <!-- Begin: Added/Updated in [Next Version] -->
+	<string name="hint_evan_book">
+	    		<![CDATA[
+				<p>¿Sabía que el autor de la versión original de Book Catalogue (Evan Leybourn) ha publicado 
+				un libro sobre gestión ágil de negocios (Agile Business Management)?</p>
+				<p>Si está interesado en esta obra, puede encontrar más información en:\n\n
+				<a href="http://theagiledirector.com/book">http://theagiledirector.com/book</a>
+				</p>
+			]]>
+    </string>
+
+    <!-- End: Added/Updated in 5.0.9 -->
+
+    <!-- Begin: Added/Updated in 5.1.0 -->
     
     <!--  Explanatory text for 'import' dialogue -->
-    <string name="import_books_blurb">Se importarán los libros del fichero. Seleccione una opción para comenzar la importación, o pulse \'back\' para cancelar:</string>
+    <string name="import_books_blurb">Se importarán los libros de este fichero. Seleccione una de las dos opciones propuestas para empezar la importación, o pulse \'Atrás\' para cancelar:</string>
     <!-- Description of the 'import all books' option -->
-    <string name="all_books_blurb">Importar todos los libros del fichero, actulizando los que existan y añadiendo los nuevos.</string>
+    <string name="all_books_blurb">Importar todos los libros del fichero, actualizando los que existan y añadiendo los nuevos.</string>
     <!-- Menu text for the 'import/export new & changed' option -->
     <string name="new_and_changed_books">Libros nuevos y actualizados</string>
     <!-- Description of the 'import new & changed' option -->
-    <string name="new_and_changed_books_blurb">Importar sólo los libros nuevos, o los que tienen fecha de actualizaicón más reciente en el fichero. Esto es útil para sincronizar dispositivos.</string>
+    <string name="new_and_changed_books_blurb">Importar sólo los libros nuevos, o los que tienen fecha de actualización más reciente en el fichero. Esto es útil para sincronizar dispositivos.</string>
     <!-- Descriptive text associated with import options not available with older archives -->
     <string name="old_archive_blurb">Esta opción no está soportada para versiones de archivo antiguas.</string>
     <!-- Part of the progress message displayed when importing books -->
     <string name="n_created_m_updated">%1$s creados, %2$s actualizados</string>
 
     <!--  Explanatory text for 'export' dialogue -->
-    <string name="export_books_blurb">Se exportarán los libros de su catálogo. Seleccione una opción para iniciar la exportación, o pulse \'back\' para cancelar:</string>
+    <string name="export_books_blurb">Se exportarán los libros de su catálogo. Seleccione una opción para iniciar la exportación, o pulse \'Atrás\' para cancelar:</string>
     <!-- Description of the 'import all books' option -->
-    <string name="export_all_books_blurb">Se exportarán a un fichero todos los libros del catálogo.</string>
+    <string name="export_all_books_blurb">Se exportarán al fichero todos los libros del catálogo.</string>
     <!-- Description of the 'export new & changed' option -->
-    <string name="export_new_and_changed_books_blurb">Sólo se exportarán los libros nuevos o modificados después de la última exportación. Esto es útil para sincronizar dispositivos.</string>
+    <string name="export_new_and_changed_books_blurb">Exportar sólo libros nuevos o modificados desde la última copia de seguridad completa. Esto es muy útil para sincronizar dispositivos.</string>
     <!-- Part of the progress message displayed when exporting books -->
     <string name="n_exported">%1$s exportados</string>
 
     <!-- Displayed in progress dialog when exporting covers in incremental mode -->
     <string name="covers_progress_incr">%1$s portadas procesadas (%2$s no encontradas, %3$s saltadas)</string>
     
-    <!-- End: Added/Updated in [Next Version] -->
+    <!-- Explanatory note for 'export all' option -->
+    <string name="export_all_blurb">Se exportarán al fichero todos los libros, portadas, configuraciones y estilos personalizados.</string>
+    <!-- Explanatory note for 'advanced export' option -->
+    <string name="export_advanced_blurb">Seleccione lo que desea exportar al fichero.</string>
+    <!-- Introduction for 'advanced export' option -->
+    <string name="export_advanced_heading">Seleccione lo que desea exportar:</string>
+    
+    <!-- Text for button -->
+    <string name="book_details">Detalles de los libros</string>
+    <!-- Brief descriptionn -->
+    <string name="book_details_blurb">Todos los datos de todos los libros</string>
+    <!-- Text for button -->
+    <string name="cover_images">Portadas</string>
+    <!-- Brief descriptionn -->
+    <string name="cover_images_blurb">Portadas de todos los libros seleccionadas. La exportación requerirá mucho más tiempo.</string>
+    <!-- Brief descriptionn -->
+    <string name="preferences_blurb">Preferencias y estilos definidos por el usuario</string>
+    
+    <!-- Explanatory note for export date (not yet implemented) -->
+    <string name="export_advanced_date_blurb">Si lo desea, especifique una fecha para seleccionar los libros o portadas que se exportarán:</string>
+    
+    <!-- Explanatory note for export date (not yet implemented) -->
+    <string name="all_books_added_or_updated_since">Todos los libros añadidos o actualizados desde:</string>
+    <!-- Explanatory note for export data since last backup -->
+    <string name="all_books_added_or_updated_since_last_full_backup">Todos los libros añadidos o actualizados desde la última copia de seguridad completa</string>
+
+    <!-- Short text for 'n books' -->
+    <plurals
+        name="n_books">
+        <item quantity="zero">ningún libro</item>
+        <item quantity="one">1 libro</item>
+        <item quantity="other">%1$s libros</item>
+    </plurals>
+
+    <!-- Short text for 'n covers' -->
+    <plurals
+        name="n_covers">
+        <item quantity="zero">ninguna portada</item>
+        <item quantity="one">1 portada</item>
+        <item quantity="other">%1$s portadas</item>
+    </plurals>
+
+    <!-- Used for concatenating two strings, eg. "3 books, 2 covers" (probably only important on RTL languages)-->
+    <string name="a_comma_b">%1$s, %2$s</string>
+    
+    <!-- Short progress message -->
+    <string name="searching_directory_ellipsis">Buscando directorio&#8230;</string>
+
+    <string name="new_in_510">
+		<![CDATA[
+			<p><b>Novedades en la versión 5.1.0</b>\n\n
+				* Traducción al italiano (Eugenio Davolio)\n\n
+				* Traducción al español (José M. Galdo)\n\n
+				* Traducción al turco (Emir Sarı)\n\n
+				* Opción para exportar a archivo sólo libros nuevos / actualizados y para excluir portadas (o libros)\n\n
+				* Mejor tamaño de miniaturas en listas para pantallas de mucha resolución\n\n
+				* Nuevas opciones para buscar libros del mismo autor o serie en Amazon\n\n
+				* Corrección de otros pequeños errores\n\n
+			</p>
+		]]>
+    </string>
+    
+    <!-- Menu item -->
+    <string name="amazon_books_in_series">Libros de la misma serie</string>
+    <!-- Menu item -->
+    <string name="amazon_books_by_author">Libros del mismo autor</string>
+    <!-- Menu item -->
+    <string name="amazon_books_by_author_in_series">Libros del autor/serie</string>
+    
+    <!-- Hint text displayed when user enters the book listw -->
+    <string name="hint_book_list">Si pulsa sobre un libro se muestran sus detalles. Si mantiene pulsado, se muestran más opciones.</string>
+
+    <!-- TRANLATORS NOTE: I HAVE UPDATED THE new_in_510, above! Sorry. -->
+
+    <!-- Preference VALUE, displayed in a preference activity -->
+    <string name="zxing_scanner">Zxing Scanner</string>
+
+    <!-- Heading in 'about' dialog -->
+    <string name="special_thanks_label">Agradecimientos</string>
+    
+    <!-- Credits in the 'about' dialog -->
+    <string name="translators_blurb">BookCatalogue es fruto del esfuerzo de mucha gente, y no tendría un uso tan extendido sin la generosa aportación de nuestros traductores (voluntarios): Eugenio Davolio, José M. Galdo, Imkal, Gideon van Melle, Emir Sarı, Nick Silin y Robert Wetzlmayr (si nos hemos olvidado de alguien, por favor, díganoslo).</string>
+
+    <!-- End: Added/Updated in 5.1.0 -->
 
 </resources>


### PR DESCRIPTION
Hello Evan, Philip,

As far as I have seen, Spanish translation is completed. Please let me know if you find any error or mistake. I have translated the new strings and also updated some from previous releases with misspelling errors or even completely wrong.

I have doubts with the translation of the description of the first improvement in version 5.0.0. I do not know the meaning of "\'fling\' support!".

On the other hand, I have seen that the Spanish description shown for the app in Google Play Store can be improved (I would say it is difficult to understand for a Spanish speaking person). I do not know how to change it, so I leave this task for you. Here is my proposed description:

"Aplicación gratuita para la gestión de su biblioteca personal, fácil de utilizar y con Licencia de uso Público (GPL).
Los libros se pueden añadir manualmente, por ISBN o escaneando su código de barras.
¡Realice una copia de seguridad y exporte su catálogo antes de actualizar!
Book Catalogue NO es un lector de libros.
Funcionalidades:
- Ordenador por autor (apellido), título, serie, etc.
- Estilos de listas definidos por el usuario
- Búsqueda de datos en Amazon, Google Books, goodreads y LibraryThing
- Búsqueda de libros
- Miniaturas de portadas (descarga, galería o cámara)
- Préstamo de libros
- Sincronización con goodreads
- Exportación y copia de seguridad
- Bibliotecas (los libros pueden estar en varias biblitecas a la vez)
  ¿Quiere una lista de deseos? Cree una biblioteca con ese nombre y añada libros.
  Póngase en contacto con nosotros si tiene cualquier problema tras una actualización.
  Wiki en:
  https://github.com/eleybourn/Book-Catalogue/wiki
  Historia completa en:
  https://raw.github.com/eleybourn/Book-Catalogue/master/README
  Historia reciente:"

Good luck with the new version. 
