### PR TITLE
Fix French translation

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -17,7 +17,7 @@
     <string name="debug_email">eleybourn@gmail.com;grunthos@rhyme.com.au</string>
     <string name="loaned_to_2">\u2192</string>
     <string name="isbn">ISBN</string>
-    <string name="series_num">#</string>
+    <string name="series_num">No</string>
 
     <item name="TAG_POSITION" type="id"></item>
     <item name="TAG_ORIGINAL_VALUE" type="id"></item>
@@ -34,23 +34,23 @@
 <![CDATA[
 	<p><b>Nouveautés de la 4.2</b>\n\n
 		* Dates supportées jusqu\'en l\'an 0 ainsi que les dates partielles\n\n
-		* Les descriptions en HTML s\'affichent correctement lors du click sur \"Modifier\"\n\n
+		* Les descriptions en HTML s\'affichent correctement lors du click sur « Modifier »\n\n
 		* Paramètre de sélection de l\'image entière lors du recadrage\n\n
 		* Paramètre de rotation automatique des photos\n\n
-		* Paramètre pour l\'utilisation d\'un outil de recadrage externe (Expérimental)\n\n
-		* Nouvelles options dans le menu "Plus" \n\n
+		* Paramètre pour l\'utilisation d\'un outil de recadrage externe (expérimental)\n\n
+		* Nouvelles options dans le menu « Plus » \n\n
 		* Mise à jour de la version française (Imkal)\n\n
 		* Mise à jour de la version allemande (Robert Wetzlmayr)\n\n
 		* Mise à jour de la version russe (Nick Silin)\n\n
-		* Mise à jour des boutons OK & Annuler pour se conformer aux nouveaux standards Android\n\n
+		* Mise à jour des boutons « OK » et « Annuler » pour se conformer aux nouveaux standards Android\n\n
 		* Clavier complet disponible pour l\'introduction d\'ASINs\n\n
-		* Sauvegarde des 5 derniers fichiers d\'export\n\n
+		* Sauvegarde des cinq derniers fichiers d\'export\n\n
 		* Meilleure détection des changements lors de l\'édition d\'un livre\n\n
-		* Support d\'un choix plus large d\'explorateurs de la Galerie et de fichiers\n\n
+		* Support d\'un choix plus large d\'explorateurs de la galerie et de fichiers\n\n
 		* Meilleure gestion des dates lors de l\'import/export/sync\n\n
 		* Correction de la gestion des doubles dans les titres d\'une anthologie\n\n
 		* Correction d\'un certain nombre de bogues\n\n
-		Tous nos remerciements à nos dévoués Beta Testeurs et nos traducteurs.\n\n
+		Tous nos remerciements à nos dévoués bêta-testeurs et nos traducteurs.\n\n
 		Tous les bugs et erreurs sont à imputer à Grunthos. Et envoyez-nous vos rapports de bugs.
 			</p>
 		]]>
@@ -58,7 +58,7 @@
     <string name="new_in_421">
 <![CDATA[
 	<p><b>Nouveautés de la version 4.2.1</b>\n\n
-		* Correction de crash lors de l\'utilisation Tout étendre\n\n
+		* Correction de crash lors de l\'utilisation « Tout étendre »\n\n
 			</p>
 		]]>
     </string>
@@ -87,10 +87,10 @@
     <string name="new_in_500">
 <![CDATA[
 	<p><b>Nouveau dans la version 5.0.0</b>\n\n
-		* Ajout d\'une vue en mode lecture avec les détails du livre et support du défilement par \'balayage\'! (Voir \"Autres Préférences\") (Nick Silin)\n\n
+		* Ajout d\'une vue en mode lecture avec les détails du livre et support du défilement par « balayage »! (voir « Autres préférences ») (Nick Silin)\n\n
 		* Archivage et restauration du catalogue complet incluant les couvertures, les paramètres et les styles\n\n
 		* Interface améliorée avec une barre d\'action pour une utilisation plus facile sans bouton de menu\n\n
-		* Support du scanner pic2shop (Meilleur pour les focus fixe, en faible lumière et les caméras frontal)\n\n
+		* Support du scanner pic2shop (meilleur pour les focus fixe, en faible lumière et les caméras frontal)\n\n
 		* Goodreads présent dans le menu prinicpal si la connection est validée\n\n
 		* Validation au plus tôt de la connection internet lors d\'un scan.\n\n
 		* Mise à jour de la version allemande (Robert Wetzlmayr)\n\n
@@ -107,9 +107,9 @@
 
     <!-- Begin : String Section -->
 
-    <string name="bad_scanner">Votre scanner de code barre ne semble pas être compatible avec Book Catalogue. Nous vous recommandons d\'installer le scanner de code barre de Zxing et, s\'il est déjà installé, de désinstaller puis de le réinstaller.</string>
+    <string name="bad_scanner">Votre scanner de code barre ne semble pas être compatible avec Book Catalogue. Nous vous recommandons d\'installer le scanner de code barre de Zxing et, s\'il est déjà installé, de le désinstaller puis le réinstaller.</string>
     <string name="show_book_under_primary_thing">Sous %1$s principal(e) seulement</string>
-    <string name="retry_x_of_y_next_at_z">Essai %1$s de %2$s Suivant à %3$s</string>
+    <string name="retry_x_of_y_next_at_z">Essai %1$s de %2$s, suivant à %3$s</string>
     <string name="menu_insert">Ajouter un livre</string>
     <string name="menu_delete">Supprimer un livre</string>
     <string name="author">Auteur</string>
@@ -123,18 +123,18 @@
     <string name="pages">Pages</string>
     <string name="confirm_add">Ajouter le livre ?</string>
     <string name="confirm_update">Mettre à jour</string>
-    <string name="nobooks">Il n\'y a pas de livre dans cette biblothèque. Merci d\'en ajouter par le menu en bas de cet écran.</string>
+    <string name="nobooks">Il n\'y a pas de livre dans cette biblothèque. Veuillez en ajouter par le menu en bas de cet écran.</string>
     <string name="menu_sort_by_author_expanded">Tout étendre</string>
     <string name="menu_sort_by">Trier par</string>
     <string name="menu_sort_by_author_collapsed">Tout réduire</string>
     <string name="sort_title">Book Catalogue : par titre</string>
-    <string name="edit_title">Book Catalogue : Modifier le livre</string>
+    <string name="edit_title">Book Catalogue : modifier le livre</string>
     <string name="menu_insert_isbn">Ajouter par ISBN</string>
     <string name="menu_insert_barcode">Ajouter par code barre</string>
     <string name="search">Recherche</string>
     <string name="cancel">Annuler</string>
     <string name="confirm_save">Sauvegarder le livre</string>
-    <string name="nobookshelves">Vous n\'avez pas encore créé de bibliothèque. Merci d\'en ajouter une par le menu en bas de cet écran.</string>
+    <string name="nobookshelves">Vous n\'avez pas encore créé de bibliothèque. Veuillez en ajouter une par le menu en bas de cet écran.</string>
     <string name="menu_insert_bs">Créer une bibliothèque</string>
     <string name="confirm_add_bs">Ajouter une bibliothèque</string>
     <string name="menu_bookshelf">Gérer les bibliothèques</string>
@@ -144,10 +144,10 @@
     <string name="bookshelf_label">Bibliothèque : </string>
     <string name="all_books">Tous les livres</string>
     <string name="isbn_found">ISBN scanné. Recherche en cours.</string>
-    <string name="title_isbn_search">Book Catalogue : recherche ISBN</string>
+    <string name="title_isbn_search">Book Catalogue : recherche par ISBN</string>
     <string name="title_manage_bs">Book Catalogue : gérer les biblothèques</string>
-    <string name="title_edit_bs">Book Catalogue : Modifier la bibliothèque</string>
-    <string name="book_exists">Le livre que vous tentez d\'ajouter existe déjà.</string>
+    <string name="title_edit_bs">Book Catalogue : modifier la bibliothèque</string>
+    <string name="book_exists">Le livre que vous tentez d\'ajouter est déjà présent.</string>
     <string name="search_label">Rechercher des livres</string>
     <string name="search_hint">Rechercher un auteur ou un titre</string>
     <string name="book_not_found">Le livre n\'a pas été trouvé. Il est parfois possible de trouver le code barre à l\'intérieur de la première page de couverture. Sinon merci d\'entrer les détails manuellement.</string>
@@ -156,16 +156,16 @@
     <string name="export_complete">Export vers la carte SD terminé.</string>
     <string name="import_data">Importer les livres</string>
     <string name="import_alert">Attention ! L\'import de données peut provoquer la mise à jour de livres avec de nouvelles informations si les identifiants importés sont identiques à ceux existants. Cela est généralement correct si vous n\'avez modifié qu\'un champ dans un fichier exporté. Si vous avez intégralement créé un livre, assurez vous que le champ identifiant est vide.</string>
-    <string name="export_failed">ERREUR : l\'export vers la carte SD a échoué. </string>
-    <string name="import_failed_is_location_correct">ERREUR: l\'import depuis la carte SD a échoué. Le fichier se trouve-t-il au bon endroit ?</string>
-    <string name="search_title">Book Catalogue : Résultats de recherche</string>
+    <string name="export_failed">Erreur : l\'export vers la carte SD a échoué. </string>
+    <string name="import_failed_is_location_correct">Erreur: l\'import depuis la carte SD a échoué. Le fichier se trouve-t-il au bon endroit ?</string>
+    <string name="search_title">Book Catalogue : résultats de recherche</string>
     <string name="results_found">Des résultats ont été trouvés.</string>
     <string name="administration_label">Administration</string>
-    <string name="administration_title">Book Catalogue : Administration</string>
+    <string name="administration_title">Book Catalogue : administration</string>
     <string name="menu_administration">Admin</string>
     <string name="install_scan_title">Installer le scanner de code barre</string>
-    <string name="version_number">Numéro de version:</string>
-    <string name="donate">Si vous souhaitez supporter le développement de cette application, les donations sont possibles par Amazon Wishlist ou par le bouton Paypal ci-dessous. Je suis en Australie, ce qui rend impossible la publication d\'une version payante :-) .</string>
+    <string name="version_number">Numéro de version :</string>
+    <string name="donate">Si vous souhaitez supporter le développement de cette application, les donations sont possibles par Amazon Wishlist ou par le bouton Paypal ci-dessous. Je suis en Australie, ce qui rend impossible la publication d\'une version payante. :-)</string>
     <string name="unable_to_connect_amazon">Connexion à Amazon impossible</string>
     <string name="upgrade_title">Depuis votre dernière mise à jour</string>
     <string name="edit_book">Modifier le livre</string>
@@ -178,8 +178,8 @@
     <string name="loan_to">Prêter le livre à :</string>
     <string name="returned">Rendu</string>
     <string name="name">Nom</string>
-    <string name="webpage_label">Site web:</string>
-    <string name="sourcecode_label">Code source:</string>
+    <string name="webpage_label">Site web :</string>
+    <string name="sourcecode_label">Code source :</string>
     <string name="donate_label">Don</string>
     <string name="about_label">À propos de cette application</string>
     <string name="administration_functions_label">Fonctions</string>
@@ -196,13 +196,13 @@
     <string name="update_fields">Mise à jour automatique des champs</string>
     <string name="select_fields_to_update">Sélection des champs à mettre à jour</string>
     <string name="select_fields_to_update_help">Les champs sélectionnés vont être mis à jour à partir d\'Internet. Les champs non sélectionnés ne seront pas modifiés.</string>
-    <string name="overwrite_thumbnail">Les champs sélectionnés vont être mis à jour tels que montré; en option, les vignettes peuvent être téléchargées pour TOUS les livres.\n\nVoulez-vous remplacer toutes les vignettes existantes ? Attention, cela peut prendre du temps.</string>
+    <string name="overwrite_thumbnail">Les champs sélectionnés vont être mis à jour tels que montré ; en option, les vignettes peuvent être téléchargées pour tous les livres.\n\nVoulez-vous remplacer toutes les vignettes existantes ? Attention, cela peut prendre du temps.</string>
     <string name="yes">Oui</string>
     <string name="no">Non</string>
     <string name="ok">OK</string>
     <string name="download_thumbs">Les vignettes sont en cours de téléchargement en arrière plan.</string>
     <string name="search_fail">La recherche du livre a échoué. Merci de vérifier vos réglages réseau.</string>
-    <string name="search_exception">Recherche en échec pendant %1$s: %2$s</string>
+    <string name="search_exception">Recherche en échec pendant %1$s : %2$s</string>
     <string name="hello">Book Catalogue !</string>
     <string name="menu_delete_thumb">Supprimer la vignette</string>
     <string name="help">Aide</string>
@@ -214,7 +214,7 @@
     <string name="same_author">Toutes les histoires de cette anthologie sont écrites par le même auteur.</string>
     <string name="menu_delete_anthology">Supprimer ce titre de l\'anthologie</string>
     <string name="is_anthology">Ce livre est-il une anthologie ?</string>
-    <string name="populate_anthology_titles">Renseigner les titres automatiquement (EXPÉRIMENTAL)</string>
+    <string name="populate_anthology_titles">Renseigner les titres automatiquement (expérimental)</string>
     <string name="automatic_population_failed">La recherche automatique des titres a échoué.</string>
     <string name="anthology">Anthologie</string>
     <string name="anthology_confirm">Merci de confirmer que les titres de cette anthologie sont corrects.</string>
@@ -251,17 +251,17 @@
     <string name="format5">Guide</string>
     <string name="description">Description</string>
     <string name="genre">Genre</string>
-    <string name="auto_update">Voulez-vous désormais mettre à jour automatiquement les champs suivants :\n* Genre \n* Description \n* Thumbnails\n\n Si vous choisissez d\'annuler, vous pourrez toujours y accéder depuis la page d\'Administration</string>
+    <string name="auto_update">Voulez-vous désormais mettre à jour automatiquement les champs suivants :\n* genre ; \n* description ; \n* miniatures ?\n\n Si vous choisissez d\'annuler, vous pourrez toujours y accéder depuis l'écran d\'administration</string>
     <string name="notset">Non défini</string>
     <string name="menu_search">Rechercher des livres</string>
     <string name="menu_insert_name">Ajouter par nom</string>
-    <string name="isbn_name_search_help">L\'ajout de livres par ISBN est plus précis que par auteur ou titre, et généralement préférable. Rappelez-vous qu\'il est parfois possible de trouver le bon code barre à l\'intérieur de la couverture. \n\n</string>
-    <string name="help_click_here">Merci de cliquer ici pour accéder à l\'aide en ligne.</string>
+    <string name="isbn_name_search_help">L\'ajout de livres par ISBN est plus précis que par auteur ou titre, et généralement préférable. Rappelez-vous qu\'il est parfois possible de trouver le bon code barre à l\'intérieur de la couverture.\n\n</string>
+    <string name="help_click_here">Veuillez cliquer ici pour accéder à l\'aide en ligne.</string>
     <string name="backup_database">Sauvegarder la base de données</string>
     <string name="vldt_unable_to_get_value">Impossible d\'obtenir la valeur de \'%s\'</string>
     <string name="vldt_integer_expected">Valeur entière attendue pour \'%s\'</string>
     <string name="vldt_real_expected">Valeur décimale attendue pour \'%s\'</string>
-    <string name="vldt_date_expected">Date attendue pour  \'%s\'</string>
+    <string name="vldt_date_expected">Date attendue pour \'%s\'</string>
     <string name="vldt_boolean_expected">Valeur booléenne (0,1,t,f,true,false) attendue pour \'%s\'</string>
     <string name="vldt_nonblank_required">Valeur non vide attendue pour \'%s\'</string>
     <string name="vldt_blank_required">Le champ \'%s\' doit être vide</string>
@@ -276,7 +276,7 @@
     <string name="columns_are_blank">Les colonnes %1$s sont toutes vides à la ligne %2$d</string>
     <string name="save">Sauvegarder</string>
     <string name="add">Ajouter</string>
-    <string name="noauthors">Il n\'y a pas d\'auteur pour ce livre. Merci d\'en ajouter un en utilisant la zone de texte et le bouton en haut de cet écran.</string>
+    <string name="noauthors">Il n\'y a pas d\'auteur pour ce livre. Veuillez ajouter un en utilisant la zone de texte et le bouton en haut de cet écran.</string>
     <string name="noseries">Il n\'y a pas de série pour ce livre. Vous pouvez en ajouter une en utilisant la zone de texte et le bouton en haut de cet écran.</string>
     <string name="cover_not_set">Couverture non définie</string>
     <string name="cover_corrupt">Couverture corrompue</string>
@@ -286,11 +286,11 @@
     <string name="and_others">et cie.</string>
     <string name="set_series">Définir la série&#8230;</string>
     <string name="author_already_in_list">L\'auteur est déjà dans la liste</string>
-    <string name="author_is_blank">Le champ Auteur est vide</string>
+    <string name="author_is_blank">Le champ « auteur » est vide</string>
     <string name="series_already_in_list">La série est déjà dans la liste</string>
-    <string name="series_is_blank">Le champ Série est vide</string>
-    <string name="export_failed_sdcard">Export en échec - Impossible d\'écrire sur la carte SD</string>
-    <string name="thumbnail_failed_sdcard">Téléchargement de vignette en échec - Impossible d\'écrire sur la carte SD</string>
+    <string name="series_is_blank">Le champ « série » est vide</string>
+    <string name="export_failed_sdcard">Export en échec : impossible d\'écrire sur la carte SD</string>
+    <string name="thumbnail_failed_sdcard">Téléchargement de miniature en échec : impossible d\'écrire sur la carte SD</string>
     <string name="skip_title">Passer - %s</string>
     <string name="num_books_searched">%s livres recherchés</string>
     <string name="cancelled_info">Annulé - %s</string>
@@ -298,7 +298,7 @@
     <string name="family_name">Nom de famille</string>
     <string name="given_names">Prénoms</string>
     <string name="edit_author_details">Modifier les détails de l\'auteur</string>
-    <string name="immediate_global_changes">NOTE: Toutes les modifications sont prises en compte immédiatement et globalement.</string>
+    <string name="immediate_global_changes">Note : toutes les modifications sont prises en compte immédiatement et globalement.</string>
     <string name="menu_replace_thumb">Remplacer la vignette&#8230;</string>
     <string name="menu_thumb_alt_editions">À partir d\'autres éditions&#8230;</string>
     <string name="author_required">Au moins un auteur doit être spécifié</string>
@@ -307,21 +307,21 @@
     <string name="menu_edit_author">Modifier l\'auteur&#8230;</string>
     <string name="menu_edit_series">Modifier les séries&#8230;</string>
     <string name="delete_series">Supprimer la série</string>
-    <string name="really_delete_series">Supprimer la série \'%s\'?\n\nLes livres eux-mêmes ne seront pas supprimés.\n\nEnvisagez de modifier la série et d\'en changer le nom pour conserver cette information.</string>
+    <string name="really_delete_series">Supprimer la série \'%s\' ?\n\nLes livres eux-mêmes ne seront pas supprimés.\n\nEnvisagez de modifier la série et d\'en changer le nom pour conserver cette information.</string>
     <string name="edit_series">Modifier les détails de la série</string>
     <string name="edit_author">Modifier les détails de l\'auteur</string>
     <string name="select_cover">Choisissez une couverture</string>
     <string name="no_isbn_no_editions">Impossible d\'obtenir les éditions d\'un livre sans ISBN</string>
     <string name="unsaved_edits">Des modifications n\'ont pas été sauvegardées. Voulez-vous vraiment continuer ?</string>
     <string name="unsaved_edits_title">Modifications non sauvegardées</string>
-    <string name="changed_author_how_apply">Vous avez changé le nom de l\'auteur, de\n  \'%1$s\' à \n  \'%2$s\'\nComment souhaitez vous appliquer ce changement ?\nNote : Votre choix \'%3$s\' sera pris en compte instantanément.</string>
+    <string name="changed_author_how_apply">Vous avez changé le nom de l\'auteur, de\n  \'%1$s\' à \n  \'%2$s\'.\nComment souhaitez-vous appliquer ce changement ?\nNote : votre choix \'%3$s\' sera pris en compte instantanément.</string>
     <string name="this_book">Ce livre</string>
     <string name="scope_of_change">Périmètre du changement</string>
-    <string name="changed_series_how_apply">Vous avez modifié la série de:\n  \'%1$s\' à \n  \'%2$s\'\nComment souhaitez vous appliquer ce changement ?\nNote : Votre choix \'All Books\' sera pris en compte immédiatement.</string>
+    <string name="changed_series_how_apply">Vous avez modifié la série de \n  \'%1$s\' à \n  \'%2$s\'\nComment souhaitez vous appliquer ce changement ?\nNote : votre choix \'all books\' sera pris en compte immédiatement.</string>
     <string name="unable_to_find_book">Impossible de trouver le livre demandé</string>
     <string name="list_and">et</string>
     <string name="really_delete_book">Cela effacera totalement le livre intitulé \'%1$s\' par %2$s. Êtes vous sûr de vouloir poursuivre ?</string>
-    <string name="editions_require_isbn">Retrouvre les autres éditions nécessite un ISBN</string>
+    <string name="editions_require_isbn">Retrouver les autres éditions nécessite un ISBN</string>
     <string name="no_editions">Aucune édition disponible</string>
     <string name="finding_editions">Éditions en cours de recherche&#8230;</string>
     <string name="click_on_thumb">Cliquez sur une vignette pour afficher une image plus grande</string>
@@ -343,27 +343,27 @@
     <string name="lt_gotkey">Une fois votre clé développeur obtenue (ou si vous en avez déjà une), entrez la simplement ci-dessous et elle sera utilisée pour obtenir des données supplémentaires.</string>
     <string name="developer_key">Clé développeur</string>
     <string name="require_library_thing_info">Cette fonctionnalité nécessite une clé développeur LibraryThing. Voulez-vous obtenir plus d\'informations à propos de LibraryThing ?</string>
-    <string name="uses_library_thing_info">Cette fonctionnalité est améliorée par l\'utilisation d\'une clé développeur LibraryThing. Voulez-vous obtenir plus d\'informations à propos de LibraryThing, ou désactiver ce message ?\n\nDes informations sur LibraryThing peuvent être obtenues dans l\'onglet LibraryThing des écrans d\'Administration.</string>
+    <string name="uses_library_thing_info">Cette fonctionnalité est améliorée par l\'utilisation d\'une clé développeur LibraryThing. Voulez-vous obtenir plus d\'informations à propos de LibraryThing, ou désactiver ce message ?\n\nDes informations sur LibraryThing peuvent être obtenues dans l\'onglet LibraryThing des écrans d\'administration.</string>
     <string name="reg_library_thing_title">Enregistrement LibraryThing</string>
     <string name="more_info">Plus d\'informations.</string>
     <string name="disable_dialogue">Désactiver ce message</string>
     <string name="lt_reset_messages_info">De temps en temps, cette application peut afficher des messages optionnels concernant LibraryThing. Pressez le bouton ci-dessous pour réactiver les messages désactivés.</string>
     <string name="reset">Réactiver</string>
-    <string name="send_info_text">Cliquez sur le bouton ci-dessous pour obtenir des informations à propos des plantages récents ou d\'autres erreurs, et pour les envoyer à l\'un des développeurs. Cela créera une copie complète de votre base de données ainsi que des fichiers journaux. Si vous ne souhaitez pas envoyer certains de ces fichiers, supprimez les des pièces jointes du courriel avant l\'envoi. </string>
+    <string name="send_info_text">Cliquez sur le bouton ci-dessous pour obtenir des informations à propos des plantages récents ou d\'autres erreurs, et pour les envoyer à l\'un des développeurs. Cela créera une copie complète de votre base de données ainsi que des fichiers journaux. Si vous ne souhaitez pas envoyer certains de ces fichiers, supprimez les des pièces jointes du courriel avant l\'envoi.</string>
     <string name="send_info">Envoyer les informations</string>
-    <string name="cleanup_files_text">Les fichiers supprimables occupent actuellement %s sur la carte SD. Les fichiers journaux et d\'autres données sont sauvegardées sur la carte SD à chaque mise à jour, lorsque vous sauvegardez la base de données ou lorsque l\'application plante. Cliquez sur le bouton ci-dessous pour purger ces fichiers de votre carte SD. Si vous avez fait l\'expérience de plantages ou d\'autres erreurs, envisagez d\'abord d\'utiliser le bouton \'Envoyer l\'Information\'</string>
+    <string name="cleanup_files_text">Les fichiers supprimables occupent actuellement %s sur la carte SD. Les fichiers journaux et d\'autres données sont sauvegardées sur la carte SD à chaque mise à jour, lorsque vous sauvegardez la base de données ou lorsque l\'application plante. Cliquez sur le bouton ci-dessous pour purger ces fichiers de votre carte SD. Si vous avez fait l\'expérience de plantages ou d\'autres erreurs, envisagez d\'abord d\'utiliser le bouton « envoyer l\'information »</string>
     <string name="cleanup_files">Nettoyer les fichiers</string>
     <string name="no_debug_info">Aucune information de débogage disponible</string>
-    <string name="megabytes">%.2fMB</string>
-    <string name="kilobytes">%.2fkB</string>
-    <string name="bytes">%.0f bytes</string>
-    <string name="sortby_author_given">Trier par auteur (Prénom)</string>
+    <string name="megabytes">%.2f Mo</string>
+    <string name="kilobytes">%.2f ko</string>
+    <string name="bytes">%.0f octets</string>
+    <string name="sortby_author_given">Trier par auteur (prénom)</string>
     <string name="select_bookshelves">Choisir des bibliothèques</string>
     <string name="debug_subject">Collecte des informations de débogage en cours</string>
     <string name="debug_body">Merci de prendre le temps de décrire brièvement le problèmeque vous rencontrez.</string>
     <string name="menu_duplicate">Livre en double</string>
     <string name="cannot_edit_system">Vous ne pouvez pas modifier les valeurs du système</string>
-    <string name="sortby_author_one">Trier par auteur (Premier auteur uniquement)</string>
+    <string name="sortby_author_one">Trier par auteur (premier auteur uniquement)</string>
     <string name="no_connection">Pas de connexion Internet disponible.</string>
     <string name="sortby_published">Trier par date de publication</string>
     <string name="menu_share_this">Partager</string>
@@ -377,11 +377,11 @@
     <string name="delete_event">Supprimer l\'événement</string>
     <string name="delete_task">Supprimer la tâche</string>
     <string name="my_books">Mes livres</string>
-    <string name="my_books_classic">Mes livres (Classique)</string>
-    <string name="loan_return_book">Prêter, retourner ou Modifier le livre</string>
+    <string name="my_books_classic">Mes livres (classique)</string>
+    <string name="loan_return_book">Prêter, retourner ou modifier le livre</string>
     <string name="admin_and_prefs">Administration et préférences</string>
     <string name="edit_book_send_to_gr">Envoyer à Goodreads</string>
-    <string name="goodreads_auth_blurb_part1">Goodreads est un site qui s\'est donné pour mission «d\'aider les gens à trouver et à partager les livres qu\'ils aiment». 
+    <string name="goodreads_auth_blurb_part1">Goodreads est un site qui s\'est donné pour mission « d\'aider les gens à trouver et à partager les livres qu\'ils aiment ». 
 		Ils disposent d\'une large base de données de livres et de critiques, et si vous êtes un utilisateur enregistré sur Goodreads, 
 		BookCatalogue peut y exporter ou en importer vos livres, vos bibliothèques et critiques. 
 		BookCatalogue est une application indépendante et ne nécessite pas Goodreads, 
@@ -390,7 +390,7 @@
 		à accéder à vos données Goodreads en pressant le bouton ci-dessous. Vous serez redirigé vers une page 
 		sur laquelle vous devrez vous connecter à Goodreads et autoriser cette application. Nous n\'aurons jamais 
 		connaissance de votre mot de passe, et vous pourrez désactiver cet accès sur le site Goodreads. 
-		Il est possible que vous arriviez sur une page blanche. Cliquez simplement sur le bouton Retour pour revenir ici !</string>
+		Il est possible que vous arriviez sur une page blanche. Cliquez simplement sur le bouton « retour » pour revenir ici !</string>
     <string name="location_of_book">Emplacement du livre</string>
     <string name="incorrect_key">Votre clé de développeur LibraryThing est incorrecte ou nous n\'avons pas pu nous connecter au réseau pour la vérifier.</string>
     <string name="correct_key">Votre clé de développeur LibraryThing est valable.</string>
@@ -401,7 +401,7 @@
     <string name="goodreads_access_error">Problème réseau lors de l\'accès à Goodreads : vérifiez que le site Goodreads est disponible et si le problème persiste, prenez contact avec le support.</string>
     <string name="other_preferences">Autres préférences</string>
     <string name="user_interface">Interface utilisateur</string>
-    <string name="start_in_my_books">Commencer dans \'Mes livres\'</string>
+    <string name="start_in_my_books">Commencer dans « mes livres »</string>
     <string name="include_classic_catalogue_view">Inclure la vue catalogue classique</string>
     <string name="background_tasks">Tâches en arrière plan</string>
     <string name="cleanup_old_tasks">Nettoyer les anciennes tâches</string>
@@ -430,7 +430,7 @@
     <string name="goodreads_auth_failed">Échec de l\'autorisation Goodreads</string>
     <string name="goodreads_auth_successful">Autorisation Goodreads accordée</string>
     <string name="authorized">Autorisé</string>
-    <string name="not_authorized">Non Autorisé</string>
+    <string name="not_authorized">Non autorisé</string>
     <string name="goodreads_auth_error">Autorisation Goodreads en erreur.</string>
     <string name="if_the_problem_persists">Si le problème persiste, contactez le support via l\'aide du menu principal.</string>
     <string name="book_no_longer_exists">Le livre demandé n\'existe plus</string>
@@ -440,12 +440,12 @@
     <string name="send_all_to_goodreads_result">%1$s livres traités : %2$s envoyés avec succès, %3$s sans ISBN et %4$s avec ISBN mais non trouvés sur Goodreads</string>
     <string name="send_book_to_goodreads">Envoyer le livre %1$s à Goodreads</string>
     <string name="erase_cover_cache">Effacer le cache des couvertures</string>
-    <string name="crash_toast_text">BookCatalogue a planté. Merci de nous aider en reportant ce crash.</string>
-    <string name="crash_notif_ticker_text">BookCatalogue a planté.</string>
-    <string name="crash_notif_title">Plantage de BookCatalogue</string>
+    <string name="crash_toast_text">Book Catalogue a planté. Merci de nous aider en reportant ce crash.</string>
+    <string name="crash_notif_ticker_text">Book Catalogue a planté.</string>
+    <string name="crash_notif_title">Plantage de Book Catalogue</string>
     <string name="crash_notif_text">Merci de cliquer ici pour obtenir des détails</string>
-    <string name="crash_dialog_title">Plantage de BookCatalogue</string>
-    <string name="crash_dialog_text">BookCatalogue a planté. Décrivez ci-dessous tout ce qui vous semble opportun et pressez "OK" pour nous envoyer un courriel à propos de ce plantage. Vous pourrez lire votre courriel avant son envoi.</string>
+    <string name="crash_dialog_title">Plantage de Book Catalogue</string>
+    <string name="crash_dialog_text">Book Catalogue a planté. Décrivez ci-dessous tout ce qui vous semble opportun et pressez « OK » pour nous envoyer un courriel à propos de ce plantage. Vous pourrez lire votre courriel avant son envoi.</string>
     <string name="crash_dialog_comment_prompt">Votre commentaire (ou laisser vide) :</string>
     <string name="crash_dialog_ok_toast">Merci !</string>
     <string name="browse_books">Consulter tous les livres</string>
@@ -454,7 +454,7 @@
     <string name="booklist_unread">Non lu</string>
     <string name="no_genre">(Pas de genre)</string>
     <string name="no_title">(Pas de titre)</string>
-    <string name="no_publisher">(Pas d\' éditeur)</string>
+    <string name="no_publisher">(Pas d\'éditeur)</string>
     <string name="no_author">(Pas d\'auteur)</string>
     <string name="no_date">(Pas de date)</string>
     <string name="book_lists">Liste des livres</string>
@@ -481,12 +481,12 @@
     <string name="shelves">Rayons</string>
     <string name="management">Gestion</string>
     <string name="credentials">Certificats</string>
-    <string name="data_import_export">Import/Export de données</string>
+    <string name="data_import_export">Import ou export de données</string>
     <string name="unrecognized_task">Tâche non reconnue</string>
     <string name="rebuilding_search_index">Construction de l\'index de recherche en cours&#8230;</string>
     <string name="optimizing_databases">Optimisation de bases de données en cours&#8230;</string>
     <string name="starting_up">Démarrage&#8230;</string>
-    <string name="book_catalogue_startup">Démarrage de BookCatalogue</string>
+    <string name="book_catalogue_startup">Démarrage de Book Catalogue</string>
     <string name="book_list_state">État de la liste de livres</string>
     <string name="always_start_booklists_expanded">Toujours démarrer avec une liste de livre étendue</string>
     <string name="always_start_booklists_collapsed">Toujours démarrer avec une liste de livre réduite</string>
@@ -517,9 +517,9 @@
 		\n\nIl est aussi possible de ré-ordonner la hiérarchie en faisant glisser l\'icône à l\'extrême droite de chaque ligne.
 </string>
     <string name="hint_booklist_style_properties">Vous pouvez utiliser cet écran pour définir les caractéristiques d\'un style particulier.
-		\n\nVous pouvez changer le nom, modifier les regroupements pour changer la  to change la hiérarchie, et ajuster un grand nombre 
+		\n\nVous pouvez changer le nom, modifier les regroupements pour changer la hiérarchie, et ajuster un grand nombre 
 		d\'autres paramètres pour construire un style que vous aimerez.
-		\n\nIl est aussi possible d\'utiliser les \'Filtres de livres\' pour modifier la sélection de livresaffichée dans la liste, 
+		\n\nIl est aussi possible d\'utiliser les « filtres de livres » pour modifier la sélection de livres affichés dans la liste, 
 		par exemple pour trouver les livres que vous n\'avez pas encore lus.
 </string>
     <string name="hint_booklist_global_properties">Vous pouvez utiliser cet écran pour définir les caractéristiques par défaut de tous les styles de listes de livres.
@@ -532,14 +532,14 @@
     <string name="select_unread_only">Sélectionner les livres non lus uniquement</string>
     <string name="extra_filters">Filtres de livres</string>
     <string name="new_style">Nouveau style</string>
-    <string name="select_based_on_read_status">Sélectionner en utilisant le statut \'Lu\'</string>
+    <string name="select_based_on_read_status">Sélectionner en utilisant le statut « lu »</string>
     <string name="books_with_multiple_authors">Livres d\'auteurs multiples</string>
     <string name="books_in_multiple_series">Livres appartenant à des séries multiples</string>
     <string name="use_default_setting">Utiliser les réglages par défaut</string>
     <string name="show_book_under_each_thing">Sous chaque %1$s</string>
     <string name="format_of_author_names">Format des noms d\'auteur</string>
-    <string name="given_name_first_eg">Prénom en premier, par exemple \'Bill Smith\'</string>
-    <string name="family_name_first_eg">Nom de famille en premier, par exemple \'Smith, Bill\'</string>
+    <string name="given_name_first_eg">Prénom en premier, par exemple « Bill Smith »</string>
+    <string name="family_name_first_eg">Nom de famille en premier, par exemple « Smith, Bill »</string>
     <string name="thumbnails">Miniatures</string>
     <string name="size_of_booklist_items">Taille des éléments de liste de livres</string>
     <string name="normal">Normal</string>
@@ -547,14 +547,14 @@
     <string name="select_style">Sélectionner un style</string>
     <string name="booklist_background_style">Style d\'arrière plan de la liste de livres</string>
     <string name="textured_backgroud">Image d\'arrière plan</string>
-    <string name="plain_background_b_reduces_flicker_b">Arrière plan uni (réduit le clignottement)</string>
+    <string name="plain_background_b_reduces_flicker_b">Arrière plan uni (réduit le clignotement)</string>
     <string name="thing_must_not_be_blank">%1$s ne doit pas être vide</string>
     <string name="edit">Modifier</string>
     <string name="groupings">Groupes</string>
     <string name="will_be_shown">Sera montré</string>
     <string name="will_not_be_shown">Ne sera pas montré</string>
     <string name="preferences">Préférences</string>
-    <string name="unexpected_error">Une erreur inattendue s\'est produite. Merci d\'envoyer les détails au support par l\'option \'Aide\' du menu principal.</string>
+    <string name="unexpected_error">Une erreur inattendue s\'est produite. Merci d\'envoyer les détails au support par l\'option « aide » du menu principal.</string>
     <string name="delete_style">Supprimer le style</string>
     <string name="edit_style">Modifier le style</string>
     <string name="clone_style">Cloner le style</string>
@@ -563,12 +563,12 @@
     <string name="compact">Compact</string>
     <string name="user_defined">Défini par l\'utilisateur</string>
     <string name="builtin">Par défaut</string>
-    <string name="sort_unread">Non lu (Auteur/Séries)</string>
+    <string name="sort_unread">Non lu (auteur / séries)</string>
     <string name="import_all_from_goodreads">Tout importer depuis Goodreads</string>
     <string name="requested_task_is_already_queued">La tâche demandée est déjà en cours d\'attente</string>
     <string name="export_task_is_already_queued">Un export est déjà en cours et doit être terminé avant que cette tâche ne démarre.</string>
     <string name="import_task_is_already_queued">Un import est déjà en cours et doit être terminé avant que cette tâche ne démarre.</string>
-    <string name="goodreads_action_cannot_blah_blah">Cette action ne peut être menée tant que cette application n\'est pas autorisée par Goodreads. Merci de ré-essayer après autorisation. \n\nVoulez-vous l\'autoriser maintenent ?</string>
+    <string name="goodreads_action_cannot_blah_blah">Cette action ne peut être menée tant que cette application n\'est pas autorisée par Goodreads. Merci de ré-essayer après autorisation.\n\nVoulez-vous l\'autoriser maintenent ?</string>
     <string name="tell_me_more">En savoir plus</string>
     <string name="completed">Terminé</string>
     <string name="failed">Échoué</string>
@@ -595,21 +595,21 @@
 		Cliquer sur un événement vous permettra de réaliser un ensemble d\'actions appropriées pour cet événement.</string>
     <string name="hints_have_been_reset">Les astuces ont été réinitialisées.</string>
     <string name="task_has_been_queued_in_background">La tâche a été placée en file d\'attente.</string>
-    <string name="hint_startup_screen">"Voici l'écran de démarrage par défaut de BookCatalogue. Si vous le souhaitez, vous pouvez démarrer directement dans 'Mes livres'; l'écran de démarrage préféré peut être modifié dans les préférences."</string>
+    <string name="hint_startup_screen">« Voici l'écran de démarrage par défaut de Book Catalogue. Si vous le souhaitez, vous pouvez démarrer directement dans « mes livres » ; l'écran de démarrage préféré peut être modifié dans les préférences. »</string>
     <string name="upgrading_ellipsis">Mise à niveau&#8230;</string>
     <string name="explain_goodreads_no_isbn">Les livres sélectionnés n\'ont pas d\'ISBN ; il est impossible de les synchroniser avec Goodreads. 
 		La solution la plus simple est de:
 		\n\n(1) supprimer le livre de BookCatalogue
 		\n\n(2) ajouter manuellement le livre à Goodreads par leur interface web
 		\n\n(3) Synchroniser avec goodreads
-		\n\nLe livre sera re-créé dans BookCatalogue et les deux livres seront alors liés.</string>
+		\n\nLe livre sera re-créé dans Book Catalogue et les deux livres seront alors liés.</string>
     <string name="explain_goodreads_no_match">L\'ISBN du livre choisi n\'a pas pu être trouvé sur goodreads. Il existe de multiples causes à ça : 
-		soit les données du livre sont erronées (Vérifiez l\'ISBN), soit le livre n\'est pas sur Goodreads. 
-		\n\nSi vous modifiez les données sur BookCatalogue, pressez simplement sur le bouton \'Ré-essayer\' et assurez vous 
+		soit les données du livre sont erronées (vérifiez l\'ISBN), soit le livre n\'est pas sur Goodreads. 
+		\n\nSi vous modifiez les données sur Book Catalogue, pressez simplement sur le bouton \'Ré-essayer\' et assurez vous 
 		que la tâche associée est exécutée avec succès. 
 		\n\nSi les données semblent correctes et que le livre n\'est toujours pas trouvé, il est alors nécessaire d\'ajouter manuellement un livre portant cet ISBN à Goodreads 
-		sur leur site Web. Une fois que c\est fait, vous pouvez essayer de renvoyer le livre.</string>
-    <string name="read_amp_unread">Lu &amp; Non lu</string>
+		sur leur site Web. Une fois que c\'est fait, vous pouvez essayer de renvoyer le livre.</string>
+    <string name="read_amp_unread">Lu &amp; non lu</string>
     <string name="loaned">Prêté</string>
     <string name="publication_year">Année de publication</string>
     <string name="publication_month">Mois de publication</string>
@@ -622,10 +622,10 @@
     <string name="size">Taille</string>
     <string name="updated">Mis à jour</string>
     <string name="no_export_files_found">Aucun fichier export n\'a été trouvé</string>
-    <string name="more_than_one_export_file_blah">Plusieurs fichiers export ont été trouvés ; Merci d\'en choisir un dans la liste ci-dessous</string>
+    <string name="more_than_one_export_file_blah">Plusieurs fichiers export ont été trouvés ; veuillez en choisir un dans la liste ci-dessous</string>
     <string name="problem_starting_import_arg">Un problème a été rencontré lors de l\'export : %1$s</string>
     <string name="hint_booklist_style_menu">Ce menu vous permet de sélectionner le style de la liste. 
-	 	\n\nVous pouvez également personnaliser ce menu, ainsi que créer vos propres styles de liste, en cliquant sur  \'Personnaliser\' à la fin de la liste.</string>
+	 	\n\nVous pouvez également personnaliser ce menu, ainsi que créer vos propres styles de liste, en cliquant sur « personnaliser » à la fin de la liste.</string>
     <string name="menu_edit_format">Modifier le format&#8230;</string>
     <string name="edit_format_name">Renommer le format</string>
     <string name="name_can_not_be_blank">Le nom ne peut pas être vide</string>
@@ -636,7 +636,7 @@
     <string name="generating_cover_thumbnails">Création des miniatures en cours</string>
     <string name="use_background_thread">Utiliser un thread (défilement des listes plus rapide, affichage décalé des images)</string>
     <string name="generate_immediately">Générer immédiatement (défilement des listes plus lent, affichage immédiat des images)</string>
-    <string name="sort_and_style_ellipsis">Tri &amp; Style&#8230;</string>
+    <string name="sort_and_style_ellipsis">Tri &amp; style&#8230;</string>
     <string name="disable_background_image">Désactiver l\'image d\'arrière plan</string>
     <string name="displaying_n_books_in_m_entries">Affichage de %1$s livres, parmi %2$s entrées</string>
     <string name="displaying_n_books">Affichage de %1$s livres</string>
@@ -671,12 +671,12 @@
     <string name="edit_lc_ellipsis">modifier&#8230;</string>
     <string name="getting_books_ellipsis">Chargement&#8230;</string>
     <string name="n_events_found">%1$s évènements trouvés</string>
-    <string name="last_error_e">Dernière erreur: %1$s</string>
+    <string name="last_error_e">Dernière erreur : %1$s</string>
     <string name="invalid_isbn_x_specified_in_search">ISBN incorrect dans la recherche \'%1$s\'</string>
     <string name="if_day_is_specified_month_and_year_must_be">Si le jour est précisé, le mois et l\'année doivent l\'être aussi.</string>
     <string name="if_month_is_specified_year_must_be">Si le mois est précisé, l\'année doit l\'être aussi.</string>
     <string name="main_menu">Menu principal</string>
-    <string name="use_external_image_cropper">Recadrage d\'image avec un outil externe (Expérimental)</string>
+    <string name="use_external_image_cropper">Recadrage d\'image avec un outil externe (expérimental)</string>
     <string name="auto_rotate_camera_images">Rotation automatique des photos</string>
     <string name="hint_autorotate_camera_images">Si vous devez systematiquement tourner vos photos dans le même sens, envisagez d\'autoriser la rotation automatique en changeant vos paramètres.</string>
     <string name="default_crop_frame_is_whole_image">Le cadre par défaut de l\'image à recadrer sera l\'image complète</string>
@@ -695,15 +695,15 @@
     <!-- Preference VALUE, displayed in a preference activity -->
     <string name="zxing_compatible_scanner">Scanner compatible Zxing</string>
     <!-- Preference VALUE, displayed in a preference activity -->
-    <string name="pic2shop_scanner"> Scanner Pic2Shop</string>
+    <string name="pic2shop_scanner">Scanner Pic2Shop</string>
     <!-- Preference name, displayed in a preference activity -->
     <string name="beep_if_scanned_isbn_valid">Beeper si l\'ISBN scanné est valide</string>
     <!-- Hint text displayed when user enters the book listw -->
     <string name="hint_view_only_book_details">Quand vous cliquez sur un élément de cette liste, vous pouvez choisir de d\'abord l\'ouvrir en mode lecture.
-		Voir le menu \"Autres Préférences\" pour adapter ce paramètre.</string>
+		Voir le menu « autres préférences » pour adapter ce paramètre.</string>
     <!-- Hint text displayed when user enters the 'read-only' book view -->
     <string name="hint_view_only_help">Ceci est l\'écran de consultation d\'un livre (lecture seulement); vous pouvez glisser vers la gauche ou la droite pour 
-        passer d\'un livre à l\'autre, et vous pouvez modifier le livre via le menu Options ou en cliquant sur l\'icône da la barre de navigation.
+        passer d\'un livre à l\'autre, et vous pouvez modifier le livre via le menu « options » ou en cliquant sur l\'icône da la barre de navigation.
 	</string>
     <!-- This is the heading of the 'Details' tab when editing a book. It needs to be short. "Book Details" is too long. -->
     <string name="details">Détails</string>
@@ -722,13 +722,13 @@
 		important  d\'enlever cette autoristation sur le site de Goodreads également.
 		\n\nSupprimer les données de connection enlevera l\'option Goodreads du menu principal.</string>
     <!-- Progress dialog message displayed when doing a long network operation to a web site -->
-    <string name="connecting_to_web_site">Connection au site &#8230;</string>
+    <string name="connecting_to_web_site">Connection au site&#8230;</string>
     <!-- Admin option to import -->
     <string name="backup_to_archive">Sauvegarde des données</string>
     <!-- Admin option to import -->
     <string name="import_from_archive">Restauration des données</string>
     <!-- Hint displayed when aCatalogue Backup is done -->
-    <string name="archive_complete_details">Le fichier %2$s (%3$s) a été créé dans le répertoire \"%1$s\" 
+    <string name="archive_complete_details">Le fichier %2$s (%3$s) a été créé dans le répertoire « %1$s »
 		de votre carte carte SD.\n\nVous devriez le copier sur un autre média comme sauvegarde en cas de perte, vol ou destruction de votre équipement</string>
     <!-- Displayed in progress dialog when exporting covers -->
     <string name="covers_progress">Couverture de %1$s exportée (%2$s manquante)</string>
@@ -736,9 +736,9 @@
     <!-- Heading in Admin activity -->
     <string name="advanced_options">Options avancées</string>
     <!-- Showed in progress dialog when an import starts -->
-    <string name="backing_up_ellipsis">Sauvegarde de &#8230;</string>
+    <string name="backing_up_ellipsis">Sauvegarde de&#8230;</string>
     <!-- Showed in progress dialog when an import starts -->
-    <string name="importing_ellipsis">Importation de &#8230;</string>
+    <string name="importing_ellipsis">Import de&#8230;</string>
     <!-- Content description for the 'up' icon in the folder browser -->
     <string name="up_folder">Parent</string>
     <!-- Displayed when a user tries to browse higher than the root directory, or if the parent is unable to be read -->
@@ -750,11 +750,11 @@
     <!-- Admin option to import books -->
     <string name="import_from_csv">Importer un fichier CSV</string>
     <!-- Displayed when a file/open dialog results in selecting a non-exitant file -->
-    <string name="please_select_an_existing_file">Merci de choisir un fichier existant</string>
+    <string name="please_select_an_existing_file">Veuillez choisir un fichier existant</string>
     <!-- Displayed when a file/save dialog results in selecting a directory file -->
-    <string name="please_select_a_non_directory">Merci de choisir un fichier et pas un  répertoire</string>
+    <string name="please_select_a_non_directory">Veuillez choisir un fichier et non un répertoire</string>
     <!-- Displayed in Admin menu advanced options (top make a copy of the internal database on the sdcard -->
-    <string name="copy_database">Copie de la base de données (Support Tech.)</string>
+    <string name="copy_database">Copie de la base de données (support tech.)</string>
     <!-- Items in list of options for the 'Summary Details' preference. Determines what is show in book list header -->
     <string name="show_book_count">Montrer le nombre de livres</string>
     <string name="show_first_level_and_book_count">Montrer l\'entête de 1er niveau et le nombre de livres</string>
@@ -762,13 +762,13 @@
     <!-- Displayed when an archive operation fails -->
     <string name="import_failed">Restauration échouée</string>
     <!-- Displayed when any write operation to the sd card fails -->
-    <string name="please_check_sd_writable">Merci de vérifier que votre carte SD est en mode \'ecriture\' et dispose d\'un espace suffisant</string>
+    <string name="please_check_sd_writable">Veuillez vérifier que votre carte SD est en mode \'ecriture\' et dispose d\'un espace suffisant</string>
     <!-- Displayed when any write operation to the sd card fails -->
-    <string name="please_check_sd_readable">Merci de vérifier que votre carte SD est bien accessible.</string>
+    <string name="please_check_sd_readable">Veuillez vérifier que votre carte SD est bien accessible.</string>
     
     <!-- Missed as they had no comment -->
     <string name="prefs_global_opening_book_mode">Affichage en mode visualisation</string>
-    <string name="book_details_readonly_publishing">Edition</string>
+    <string name="book_details_readonly_publishing">Édition</string>
     <string name="book_details_readonly_by">par</string>
     <string name="book_details_readonly_loaned_to">En prêt chez %1$s</string>
     
@@ -802,7 +802,7 @@
     
     <!-- Begin: Added/Updated in 5.0.4 -->
     <!-- Short Heading for 'Language' field in book details -->
-    <string name="language">Langage</string>
+    <string name="language">Langue</string>
     <string name="new_in_504">
 		<![CDATA[
 			<p><b>Nouveau dans la version 5.0.4</b>\n\n
@@ -821,12 +821,12 @@
     
     <!-- Option listed under "booklist_generation" referring to a very conservative way of generating bookslists -->
     <!-- NOTE The English version was changed to "Force Compatibility Mode" -->
-    <string name="force_compatibility_mode">Mode Compatibilité</string>
+    <string name="force_compatibility_mode">Mode compatibilité</string>
     
     <!-- Option listed under "booklist_generation" referring to a conservative way of generating bookslists -->
-    <string name="force_enhanced_compatibility_mode">Mode Compatibilité avancé</string>
+    <string name="force_enhanced_compatibility_mode">Mode compatibilité avancé</string>
     <!-- Option listed under "booklist_generation" referring to a conservative way of generating bookslists -->
-    <string name="force_fully_featured">Mode \'Toutes options\'</string>
+    <string name="force_fully_featured">Mode « toutes options »</string>
     <!-- Default Option listed under "booklist_generation" referring to a conservative way of generating bookslists -->
     <string name="automatically_use_recommended_option">Recommandations automatiques</string>
     
@@ -834,7 +834,7 @@
 		<![CDATA[
 			<p><b>Nouveau dans la version 5.0.5</b>\n\n
 				* Tri décroissant sur la date d\'ajout \n\n
-				* Mise à jour de la version française(Imkal)\n\n
+				* Mise à jour de la version française (Imkal)\n\n
 				* Correction de bogues\n\n
 			</p>
 		]]>
@@ -845,7 +845,7 @@
     <string name="new_in_508">
 		<![CDATA[
 			<p><b>Nouveau dans la version 5.0.8</b>\n\n
-				* Mise à jour de la version allemande(Robert Wetzlmayr)\n\n
+				* Mise à jour de la version allemande (Robert Wetzlmayr)\n\n
 			</p>
 		]]>
     </string>
@@ -877,20 +877,20 @@
     <!-- Begin: Added/Updated in 5.1.0 -->
     
     <!--  Explanatory text for 'import' dialogue -->
-    <string name="import_books_blurb">Les livres de cette sauvegarde vont être importés. Choisissez une des 2 options au début de l\'import, ou cliquez sur \'Retour\' pour annuler:</string>
+    <string name="import_books_blurb">Les livres de cette sauvegarde vont être importés. Choisissez une des deux options au début de l\'import, ou cliquez sur « retour » pour annuler:</string>
     <!-- Description of the 'import all books' option -->
-    <string name="all_books_blurb">Tous les livres de la sauvegardes seront importés en meetant à ceux ceux existant et en ajoutant les nouveaux.</string>
+    <string name="all_books_blurb">Tous les livres de la sauvegardes seront importés en mettant à jour ceux existant et en ajoutant les nouveaux.</string>
     <!-- Menu text for the 'import/export new & changed' option -->
-    <string name="new_and_changed_books">Livres nouveaux et mis à jour</string>
+    <string name="new_and_changed_books">Nouveaux livres et livres mis à jour</string>
     <!-- Description of the 'import new & changed' option -->
-    <string name="new_and_changed_books_blurb">Seul les livres récemment ajoutés ou mis à jour dans la sauvegarde seront mis à jour. Cette option est utile lors de la synchronisation de 2 appareils.</string>
+    <string name="new_and_changed_books_blurb">Seuls les livres récemment ajoutés ou mis à jour dans la sauvegarde seront mis à jour. Cette option est utile lors de la synchronisation de deux appareils.</string>
     <!-- Descriptive text associated with import options not available with older archives -->
     <string name="old_archive_blurb">Cette option n\'est pas supportée par les anciennes sauvegardes.</string>
     <!-- Part of the progress message displayed when importing books -->
     <string name="n_created_m_updated">%1$s ajoutés, %2$s mis à jour</string>
 
     <!--  Explanatory text for 'export' dialogue -->
-    <string name="export_books_blurb">Les livres de votre catalogue seront exporté. Choisissez une des 2 options pour exporter vos livres ou cliquez sur \'Retour\' pour annuler:</string>
+    <string name="export_books_blurb">Les livres de votre catalogue seront exportés. Choisissez une des deux options pour exporter vos livres ou cliquez sur « retour » pour annuler :</string>
     <!-- Description of the 'import all books' option -->
     <string name="export_all_books_blurb">Tous les livres de votre catalogue seront enregistrés dans la sauvegarde.</string>
     <!-- Description of the 'export new & changed' option -->
@@ -906,7 +906,7 @@
     <!-- Explanatory note for 'advanced export' option -->
     <string name="export_advanced_blurb">Selection de ce qui doit être enregistré dans la sauvegarde.</string>
     <!-- Introduction for 'advanced export' option -->
-    <string name="export_advanced_heading">Choissisez:</string>
+    <string name="export_advanced_heading">Choisissez :</string>
     
     <!-- Text for button -->
     <string name="book_details">Details des livres</string>
@@ -917,13 +917,13 @@
     <!-- Brief descriptionn -->
     <string name="cover_images_blurb">Couvertures de tous les livres sauvegardés. La taille de la sauvegarde sera plus importante.</string>
     <!-- Brief descriptionn -->
-    <string name="preferences_blurb">Paramètres et préférences (Style de liste personnel)</string>
+    <string name="preferences_blurb">Paramètres et préférences (style de liste personnel)</string>
     
     <!-- Explanatory note for export date (not yet implemented) -->
     <string name="export_advanced_date_blurb">Definissez la date à prendre en compte pour l\'archivage des livres (optionnel):</string>
     
     <!-- Explanatory note for export date (not yet implemented) -->
-    <string name="all_books_added_or_updated_since">Tous les livres ajoutés ou mis à jour depuis le:</string>
+    <string name="all_books_added_or_updated_since">Tous les livres ajoutés ou mis à jour depuis le :</string>
     <!-- Explanatory note for export data since last backup -->
     <string name="all_books_added_or_updated_since_last_full_backup">Tous les livres ajoutés ou mis à jour depuis la dernière sauvegarde complète</string>
 
@@ -968,7 +968,7 @@
     <!-- Menu item -->
     <string name="amazon_books_by_author">Livres de cet auteur</string>
     <!-- Menu item -->
-    <string name="amazon_books_by_author_in_series">Livres par auteur/serie</string>
+    <string name="amazon_books_by_author_in_series">Livres par auteur par série</string>
     
     <!-- Hint text displayed when user enters the book listw -->
     <string name="hint_book_list">Cliquez sur un livre vous montrera les détails du livre, un appui long sur un livre dans la liste vous donnera d\'autres options.</string>
@@ -984,7 +984,7 @@
     <!-- Name of the 'Default' bookshelf, created when app first installed. Needs to be short. -->
     <string name="default_bookshelf_name">Votre bibliothèque</string>
     <!-- A hint describing the benefit of folowing the Amazon links -->
-    <string name="hint_amazon_links_blurb">&lt;p&gt;Si vous achetez des livres chez amazon en sélectionnant le menu &lt;i&gt;\"%1$s\"&lt;/i&gt;, &lt;i&gt;\"%2$s\"&lt;/i&gt; or &lt;i&gt;\"%3$s\"&lt;/i&gt; , une partie du prix d\'achat sera reversée aux développeurs  %4$s.&lt;/p&gt;&lt;p&gt;Vous pouvez aussi utilisez le lien sur &lt;a href=""https://github.com/eleybourn/Book-Catalogue/wiki/Frequently-Asked-Questions-%%28FAQ%%29""&gt;notre FAQ&lt;/a&gt;(en anglais) pour vous rendre sur amazon ou Paypal.&lt;/p&gt;</string>
+    <string name="hint_amazon_links_blurb">&lt;p&gt;Si vous achetez des livres chez amazon en sélectionnant le menu « &lt;i&gt;%1$s&lt;/i&gt; », « &lt;i&gt;%2$s&lt;/i&gt; » ou « &lt;i&gt;%3$s&lt;/i&gt; », une partie du prix d\'achat sera reversée aux développeurs %4$s.&lt;/p&gt;&lt;p&gt;Vous pouvez aussi utiliser le lien sur &lt;a href=""https://github.com/eleybourn/Book-Catalogue/wiki/Frequently-Asked-Questions-%%28FAQ%%29""&gt;notre FAQ&lt;/a&gt;(en anglais) pour vous rendre sur Amazon ou PayPal.&lt;/p&gt;</string>
     <!-- Name of the new style grouping (needs to be short). -->
     <string name="update_date">Date de mise à jour</string>
     <!-- Name of the new style grouping (needs to be short). -->
@@ -1035,15 +1035,15 @@
     <!-- This is an UPDATED string copied from earlier in the file; "Google Googles" (sic) was removed from the list of scanners -->
     <string name="install_scan">Pour scanner vos livres en utilisant le code barre ISBN, vous pouvez installer le lecteur de codes barre Zxing ou pic2shop.</string>
 
-    <string name="system_locale">Système de Localisation</string>
+    <string name="system_locale">Paramètres de langue du système</string>
 
     <!-- Credits in the 'about' dialog -->
-    <string name="translators_blurb">BookCatalogue est le résultat de l\'effort de beaucoup de personnes, et n\'aurait pas une diffusion et une utilisation aussi large sans l\'aide de nos généreux traducteurs: Eugenio Davolio, José M. Galdo, Imkal, Dimitris Klisiari, Gideon van Melle, Emir Sarı, Nick Silin, and Robert Wetzlmayr (if we have forgotten someone, please tell us).</string>
+    <string name="translators_blurb">Book Catalogue est le résultat de l\'effort de beaucoup de personnes, et n\'aurait pas une diffusion et une utilisation aussi large sans l\'aide de nos généreux traducteurs: Eugenio Davolio, José M. Galdo, Imkal, Dimitris Klisiari, Gideon van Melle, Emir Sarı, Nick Silin, and Robert Wetzlmayr (if we have forgotten someone, please tell us).</string>
 
     <string name="new_in_520">
 		<![CDATA[
 			<p><b>Nouveau dans la version 5.2.0</b>\n\n
-			    * Selection de la localisation dans les Préférences\n\n
+			    * Selection de la localisation dans les préférences\n\n
 			    * Version grecque (Dimitris Klisiaris)\n\n
                 * Gestion des majuscules spécifiques à la localisation (de, fr)\n\n
                 * Amélioration dela recherche\n\n


### PR DESCRIPTION
* Use "«" and "»" as they are the unique correct French quotes (see https://fr.wikipedia.org/wiki/Guillemet#Usage_des_guillemets_en_fran.C3.A7ais)
* Fix usage of upper- and lower-case text (see https://fr.wikipedia.org/wiki/Usage_des_majuscules_en_fran%C3%A7ais)
* Fix usage of punctuation (see https://fr.wikipedia.org/wiki/Ponctuation)
* Fix various typos, plural/singular usages, etc.

There's more work to do, but it's a start