### PR TITLE
Add support for price list JSON tag

### DIFF
--- a/src/com/eleybourn/bookcatalogue/bcservices/BcService.java
+++ b/src/com/eleybourn/bookcatalogue/bcservices/BcService.java
@@ -47,6 +47,7 @@ public class BcService {
 	private static final String SERIES_NAME = "series_name";
 	private static final String SERIES_NUM = "series_num";
 	private static final String SERIES_POSITION = "series_position";
+	private static final String LIST_PRICE = "list_price";
 	/** Sync object */
 	private static final Object mApiSync = new Object();
 	/** Last time API was called; limit to 1 per second */
@@ -273,6 +274,9 @@ public class BcService {
 					}
 				}
 				case THUMBNAILS:
+					break;
+				case LIST_PRICE:
+					addIfNotPresent(bookData, CatalogueDBAdapter.KEY_LIST_PRICE, value);
 					break;
 				default:
 					Logger.logError(new RuntimeException(


### PR DESCRIPTION
Fix for following issue:
java.lang.RuntimeException: Unexpected JSON key in result: list_price, value $23.99
at com.eleybourn.bookcatalogue.bcservices.BcService.jsonResultToBookData(BcService.java:278)
at com.eleybourn.bookcatalogue.bcservices.BcSearchManager.search(BcSearchManager.java:218)
at com.eleybourn.bookcatalogue.bcservices.BcSearchManager.searchByIsbn(BcSearchManager.java:118)
at com.eleybourn.bookcatalogue.bcservices.BcSearchManager.searchBcService(BcSearchManager.java:65)
at com.eleybourn.bookcatalogue.SearchAmazonThread.onRun(SearchAmazonThread.java:21)
at com.eleybourn.bookcatalogue.ManagedTask.run(ManagedTask.java:117)