### PR TITLE
Issue#805 - Fix to set author field before add button

### DIFF
--- a/res/layout-de/edit_book.xml
+++ b/res/layout-de/edit_book.xml
@@ -42,7 +42,10 @@
                     android:id="@+id/author"
                     style="@style/dataEntryButtonStyle"
                     android:layout_width="match_parent"
-                    android:nextFocusDown="@+id/title" />
+                    android:focusableInTouchMode="true"
+                    android:nextFocusDown="@+id/title" >
+                    <requestFocus/>
+                </Button>
             </LinearLayout>
 
             <LinearLayout

--- a/res/layout-fr/edit_book.xml
+++ b/res/layout-fr/edit_book.xml
@@ -45,7 +45,10 @@
                     android:layout_alignParentLeft="true"
                     android:layout_alignParentRight="true"
                     android:layout_below="@+id/heading"
-                    android:nextFocusDown="@+id/title" />
+                    android:focusableInTouchMode="true"
+                    android:nextFocusDown="@+id/title" >
+                    <requestFocus/>
+                </Button>
             </RelativeLayout>
 
             <RelativeLayout

--- a/res/layout/edit_book.xml
+++ b/res/layout/edit_book.xml
@@ -45,7 +45,10 @@
                     android:layout_alignParentLeft="true"
                     android:layout_alignParentRight="true"
                     android:layout_below="@+id/heading"
-                    android:nextFocusDown="@+id/title" />
+                    android:focusableInTouchMode="true"
+                    android:nextFocusDown="@+id/title" >
+                    <requestFocus/>
+                </Button>
             </RelativeLayout>
 
             <RelativeLayout


### PR DESCRIPTION
Proposition for issue #805 
This sets the author field to be focused on first when the edit book layout is shown. 

I'm not sure of the issue being described in:
"So you enter the author "shift+tab" -> "enter" to add -> "tab tab tab" -> "enter" to save"."

Additionally: 
"The order should be imho: series name -> number -> add -> list -> cancel -> save."
This seems to be a description of how things are.