### PR TITLE
Data Loss Fix

### DIFF
--- a/src/com/eleybourn/bookcatalogue/EditAuthorList.java
+++ b/src/com/eleybourn/bookcatalogue/EditAuthorList.java
@@ -24,8 +24,10 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
@@ -107,6 +109,7 @@ public class EditAuthorList extends EditObjectList<Author> {
 				return;							
 			}
 
+			isSubmit = true;
 			mList.add(a);
 			mAdapter.notifyDataSetChanged();
 			t.setText("");
@@ -245,4 +248,30 @@ public class EditAuthorList extends EditObjectList<Author> {
 			return true;
 		}
 	};
+
+	private SharedPreferences spGen;
+
+	private boolean isSubmit;
+
+	@Override
+	protected void onPause() {
+		super.onPause();
+		final AutoCompleteTextView editAuthorTV = ((AutoCompleteTextView)EditAuthorList.this.findViewById(R.id.author));
+		SharedPreferences.Editor spGenEditor = spGen.edit();
+		if (isSubmit) {
+			spGenEditor.putString("editAuthor", "");
+		} else {
+			spGenEditor.putString("editAuthor", editAuthorTV.getText().toString());
+		}
+		spGenEditor.commit();
+	}
+
+	@Override
+	protected void onResume() {
+		super.onResume();
+		spGen = getSharedPreferences("EditAuthorList", MODE_PRIVATE);
+		final AutoCompleteTextView editAuthorTV = ((AutoCompleteTextView)EditAuthorList.this.findViewById(R.id.author));
+		editAuthorTV.setText(spGen.getString("editAuthor", ""));
+		isSubmit = false;
+	}
 }

--- a/src/com/eleybourn/bookcatalogue/EditSeriesList.java
+++ b/src/com/eleybourn/bookcatalogue/EditSeriesList.java
@@ -24,8 +24,10 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
@@ -105,6 +107,7 @@ public class EditSeriesList extends EditObjectList<Series> {
 				Toast.makeText(EditSeriesList.this, getResources().getString(R.string.series_already_in_list), Toast.LENGTH_LONG).show();						
 				return;							
 			}
+			isSubmit = true;
 			mList.add(series);
 			mAdapter.notifyDataSetChanged();
 			t.setText("");
@@ -261,4 +264,30 @@ public class EditSeriesList extends EditObjectList<Series> {
 			return true;
 		}
 	};
+
+	private SharedPreferences spGen;
+
+	private boolean isSubmit;
+
+	@Override
+	protected void onPause() {
+		super.onPause();
+		final AutoCompleteTextView editSeriesTV = ((AutoCompleteTextView)EditSeriesList.this.findViewById(R.id.series));
+		SharedPreferences.Editor spGenEditor = spGen.edit();
+		if (isSubmit) {
+			spGenEditor.putString("editSeries", "");
+		} else {
+			spGenEditor.putString("editSeries", editSeriesTV.getText().toString());
+		}
+		spGenEditor.commit();
+	}
+
+	@Override
+	protected void onResume() {
+		super.onResume();
+		spGen = getSharedPreferences("EditSeriesList", MODE_PRIVATE);
+		final AutoCompleteTextView editAuthorTV = ((AutoCompleteTextView)EditSeriesList.this.findViewById(R.id.series));
+		editAuthorTV.setText(spGen.getString("editSeries", ""));
+		isSubmit = false;
+	}
 }


### PR DESCRIPTION
Hello developers of Book Catalogue

I am using your app Book Catalogue. I think the app is great but I have one minor patch that could improve the user experience.

Here are some pictures to help illustrate what activities are changed in my patch: 

https://ibb.co/yFYfSrB
https://ibb.co/RzkY7HF
https://ibb.co/TtZJw7y
https://ibb.co/K073CXr
https://ibb.co/ZB14KnC

When the user tries to search for a book(either via ISBN or book name) or create an author or series. If the screen focus goes to another app or activity(for example if an incoming call forces the user to go into the phone app), or if the user accidentally closes the app or presses back, the user will lose any data they had put into this page if the app is force closed by Android.

This feature will automatically store the data when the user leaves the activity without submitting and restore said data when they restart the activity(this can be seen here https://ibb.co/ZB14KnC). Therefore, the user does not have to fill in the data again thus improving the user experience.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim